### PR TITLE
chore: add deposit page

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@defuse-protocol/defuse-sdk": "^1.4.0",
+    "@defuse-protocol/defuse-sdk": "^1.5.0",
     "@near-eth/aurora-erc20": "^2.8.0",
     "@near-eth/aurora-ether": "^3.0.0",
     "@near-eth/aurora-nep141": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@defuse-protocol/defuse-sdk": "^1.5.0",
+    "@defuse-protocol/defuse-sdk": "^1.9.0",
     "@near-eth/aurora-erc20": "^2.8.0",
     "@near-eth/aurora-ether": "^3.0.0",
     "@near-eth/aurora-nep141": "^1.5.3",

--- a/src/app/deposit/page.tsx
+++ b/src/app/deposit/page.tsx
@@ -1,13 +1,14 @@
 "use client"
 
-import type { Transaction } from "@near-wallet-selector/core"
 import React from "react"
 
 import { DepositWidget } from "@defuse-protocol/defuse-sdk"
 import Paper from "@src/components/Paper"
+import { useNearWalletActions } from "@src/hooks/useNearWalletActions"
 import { useWalletSelector } from "@src/providers/WalletSelectorProvider"
 
 export default function Deposit() {
+  const { signAndSendTransactions } = useNearWalletActions()
   const { accountId, selector } = useWalletSelector()
   return (
     <Paper title="Deposit">
@@ -15,13 +16,12 @@ export default function Deposit() {
         accountId={accountId || ""}
         signAndSendTransactionsNear={async (transactions) => {
           assert(selector, "Wallet selector is not found")
-          const wallet = await selector.wallet()
-          const transactionResult = await wallet.signAndSendTransactions({
+          const transactionResult = await signAndSendTransactions({
             transactions,
           })
-          return transactionResult && transactionResult.length > 0
-            ? transactionResult[0]
-            : ""
+          // TODO: handle transaction result
+          console.log("transactionResult", transactionResult)
+          return ""
         }}
       />
     </Paper>

--- a/src/app/deposit/page.tsx
+++ b/src/app/deposit/page.tsx
@@ -1,74 +1,35 @@
 "use client"
 
-import Image from "next/image"
+import type { Transaction } from "@near-wallet-selector/core"
 import React from "react"
-import { type FieldValues, useForm } from "react-hook-form"
 
-import Accordion from "@src/components/Accordion"
-import Button from "@src/components/Button/Button"
-import ButtonSwitch from "@src/components/Button/ButtonSwitch"
-import Form from "@src/components/Form"
-import FieldComboInput from "@src/components/Form/FieldComboInput"
+import { DepositWidget } from "@defuse-protocol/defuse-sdk"
 import Paper from "@src/components/Paper"
-import type { NetworkToken } from "@src/types/interfaces"
-
-type FormValues = {
-  tokenIn: string
-  tokenOut: string
-}
+import { useWalletSelector } from "@src/providers/WalletSelectorProvider"
 
 export default function Deposit() {
-  const { handleSubmit, register } = useForm<FormValues>()
-
-  const onSubmit = (values: FieldValues) => {
-    console.log(values, "form submit")
-  }
-  const handleSwitch = () => {
-    console.log("form switch")
-  }
-  const handleSetMax = () => {
-    console.log("form set max")
-  }
+  const { accountId, selector } = useWalletSelector()
   return (
     <Paper title="Deposit">
-      <Form<FormValues>
-        handleSubmit={handleSubmit(onSubmit)}
-        register={register}
-      >
-        <FieldComboInput<FormValues>
-          fieldName="tokenIn"
-          label="You pay"
-          selected={{ name: "USD" } as NetworkToken}
-        />
-        <ButtonSwitch onClick={handleSwitch} />
-        <FieldComboInput<FormValues>
-          fieldName="tokenOut"
-          label="You receive"
-          selected={{ name: "AURORA" } as NetworkToken}
-        />
-        <Accordion
-          leftHeaderElement={
-            <>
-              <span className="text-sm font-medium">0.184 ETH = €2,681.60</span>
-              <span className="text-sm text-gray-700">($0.361)</span>
-            </>
-          }
-          rightHeaderElement={
-            <>
-              <Image
-                src="/static/icons/fire.svg"
-                width={12}
-                height={16}
-                alt="caret-down"
-              />
-              <span className="text-sm font-medium text-gray-700">$5.56</span>
-            </>
-          }
-        />
-        <Button type="submit" size="lg" fullWidth disabled>
-          Coming soon
-        </Button>
-      </Form>
+      <DepositWidget
+        accountId={accountId || ""}
+        signAndSendTransactionsNear={async (transactions) => {
+          assert(selector, "Wallet selector is not found")
+          const wallet = await selector.wallet()
+          const transactionResult = await wallet.signAndSendTransactions({
+            transactions,
+          })
+          return transactionResult && transactionResult.length > 0
+            ? transactionResult[0]
+            : ""
+        }}
+      />
     </Paper>
   )
+}
+
+function assert(condition: unknown, msg?: string): asserts condition {
+  if (!condition) {
+    throw new Error(msg)
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,8 +17,8 @@ import { WalletSelectorProvider } from "@src/providers/WalletSelectorProvider"
 import "@radix-ui/themes/styles.css"
 import "@near-wallet-selector/modal-ui/styles.css"
 import "@near-wallet-selector/account-export/styles.css"
-import "../styles/global.scss"
 import "@defuse-protocol/defuse-sdk/styles"
+import "../styles/global.scss"
 
 const DEV_MODE = process?.env?.NEXT_PUBLIC_DEV_MODE === "true" ?? false
 

--- a/src/app/my-near-wallet-gateway/page.tsx
+++ b/src/app/my-near-wallet-gateway/page.tsx
@@ -20,6 +20,16 @@ export default function MyNearWalletGateway() {
       return
     }
 
+    if (url.searchParams.get("errorCode")) {
+      relayResultToOpenerError(url)
+      return
+    }
+
+    if (url.searchParams.get("transactionHashes")) {
+      relayResultToOpenerTransactionHashes(url)
+      return
+    }
+
     switch (url.searchParams.get("action")) {
       case "signMessage":
         void signMessage(url, selector).catch(console.error)
@@ -47,6 +57,31 @@ function relayResultToOpener(url: URL) {
   if (window.opener) {
     window.opener.postMessage(
       queryStringToObject(url.hash),
+      window.location.origin
+    )
+    window.close()
+  }
+}
+
+function relayResultToOpenerError(url: URL) {
+  if (window.opener) {
+    window.opener.postMessage(
+      {
+        errorCode: url.searchParams.get("errorCode"),
+        errorMessage: url.searchParams.get("errorMessage"),
+      },
+      window.location.origin
+    )
+    window.close()
+  }
+}
+
+function relayResultToOpenerTransactionHashes(url: URL) {
+  if (window.opener) {
+    window.opener.postMessage(
+      {
+        transactionHashes: url.searchParams.get("transactionHashes"),
+      },
       window.location.origin
     )
     window.close()

--- a/src/app/my-near-wallet-gateway/page.tsx
+++ b/src/app/my-near-wallet-gateway/page.tsx
@@ -2,7 +2,10 @@
 
 import type { WalletSelector } from "@near-wallet-selector/core"
 import { useWalletSelector } from "@src/providers/WalletSelectorProvider"
-import { deserializeSignMessageParams } from "@src/utils/myNearWalletAdapter"
+import {
+  deserializeSignAndSendTransactionsParams,
+  deserializeSignMessageParams,
+} from "@src/utils/myNearWalletAdapter"
 import { useEffect } from "react"
 
 export default function MyNearWalletGateway() {
@@ -24,6 +27,9 @@ export default function MyNearWalletGateway() {
       case "sendTransaction":
         // todo: implement transaction sending
         throw new Error("not implemented")
+      case "signAndSendTransactions":
+        void signAndSendTransactions(url, selector).catch(console.error)
+        break
       default:
         console.warn("Unknown action", {
           action: url.searchParams.get("action"),
@@ -45,6 +51,22 @@ function relayResultToOpener(url: URL) {
     )
     window.close()
   }
+}
+
+async function signAndSendTransactions(
+  url: URL,
+  walletSelector: WalletSelector
+) {
+  const paramsComponent = url.searchParams.get("params")
+  if (paramsComponent == null) {
+    throw new Error("Missing params")
+  }
+  const params = deserializeSignAndSendTransactionsParams(
+    decodeURIComponent(paramsComponent)
+  )
+
+  const wallet = await walletSelector.wallet()
+  await wallet.signAndSendTransactions(params)
 }
 
 async function signMessage(url: URL, walletSelector: WalletSelector) {

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -16,6 +16,6 @@ export type NavigationLinks = {
 
 export const LINKS_HEADER: NavigationLinks[] = [
   { href: Navigation.SWAP, label: "Swap" },
-  { href: Navigation.DEPOSIT, label: "Deposit", comingSoon: true },
+  { href: Navigation.DEPOSIT, label: "Deposit" },
   { href: Navigation.WITHDRAW, label: "Withdraw", comingSoon: true },
 ]

--- a/src/utils/myNearWalletAdapter.ts
+++ b/src/utils/myNearWalletAdapter.ts
@@ -10,7 +10,7 @@ type SignAndSendTransactionsParams = Parameters<
   // @ts-expect-error TODO: fix this
   WalletSelector["signAndSendTransactions"]
 >[0]
-type TransactionHashes = string[]
+type TransactionHashes = string
 
 const signedMessageSchema = z.object({
   accountId: z.string(),
@@ -31,7 +31,17 @@ const signMessageSchema = z.object({
   state: z.string().optional(),
 })
 
-const windowMessageSchema = z.union([signedMessageSchema, errorSchema])
+const windowMessageSchema = z.union([
+  signedMessageSchema,
+  errorSchema,
+  z.object({
+    errorCode: z.string(),
+    errorMessage: z.string(),
+  }),
+  z.object({
+    transactionHashes: z.string(),
+  }),
+])
 
 export const signMessageInNewWindow = async ({
   params,
@@ -99,10 +109,10 @@ export const signAndSendTransactionsInNewWindow = async ({
 
         switch (true) {
           case "transactionHashes" in parsedMessage.data:
-            resolve(parsedMessage?.data?.transactionHashes as TransactionHashes)
+            resolve(parsedMessage.data.transactionHashes)
             return
-          case "error" in parsedMessage.data:
-            reject(new Error(parsedMessage.data.error))
+          case "errorCode" in parsedMessage.data:
+            reject(new Error(parsedMessage.data.errorMessage))
             return
           default:
             throw new Error("exhaustive check")

--- a/src/utils/myNearWalletAdapter.ts
+++ b/src/utils/myNearWalletAdapter.ts
@@ -1,8 +1,16 @@
+import type { WalletSelector } from "@near-wallet-selector/core"
 import type {
   SignMessageParams,
   SignedMessage,
 } from "@near-wallet-selector/core/src/lib/wallet/wallet.types"
 import { z } from "zod"
+
+// Define substitute types
+type SignAndSendTransactionsParams = Parameters<
+  // @ts-expect-error TODO: fix this
+  WalletSelector["signAndSendTransactions"]
+>[0]
+type TransactionHashes = string[]
 
 const signedMessageSchema = z.object({
   accountId: z.string(),
@@ -69,9 +77,70 @@ export const signMessageInNewWindow = async ({
   })
 }
 
+export const signAndSendTransactionsInNewWindow = async ({
+  params,
+  signal,
+}: {
+  signal: AbortSignal
+  params: SignAndSendTransactionsParams
+}): Promise<TransactionHashes> => {
+  const completeAbortCtrl = new AbortController()
+
+  const promise = new Promise<TransactionHashes>((resolve, reject) => {
+    openWindowWithMessageHandler({
+      url: makeSignAndSendTransactionsUrl(params),
+      onMessage: (message) => {
+        const parsedMessage = windowMessageSchema.safeParse(message)
+
+        if (!parsedMessage.success) {
+          reject(new Error("Invalid message", { cause: parsedMessage.error }))
+          return
+        }
+
+        switch (true) {
+          case "transactionHashes" in parsedMessage.data:
+            resolve(parsedMessage?.data?.transactionHashes as TransactionHashes)
+            return
+          case "error" in parsedMessage.data:
+            reject(new Error(parsedMessage.data.error))
+            return
+          default:
+            throw new Error("exhaustive check")
+        }
+      },
+      onClose: () => {
+        reject(new Error("Window closed"))
+      },
+      signal: AbortSignal.any([signal, completeAbortCtrl.signal]),
+    })
+  })
+
+  return promise
+}
+
 function makeSignUrl(params: SignMessageParams) {
   const serializedParams = serializeSignMessageParams(params)
   return `/my-near-wallet-gateway/?action=signMessage&params=${encodeURIComponent(serializedParams)}`
+}
+
+function makeSignAndSendTransactionsUrl(params: SignAndSendTransactionsParams) {
+  const serializedParams = serializeSignAndSendTransactionsParams(params)
+  return `/my-near-wallet-gateway/?action=signAndSendTransactions&params=${encodeURIComponent(serializedParams)}`
+}
+
+export function serializeSignAndSendTransactionsParams(
+  params: SignAndSendTransactionsParams
+) {
+  const encodedParams = {
+    ...params,
+  }
+  return JSON.stringify(encodedParams)
+}
+
+export function deserializeSignAndSendTransactionsParams(
+  params: string
+): SignAndSendTransactionsParams {
+  return JSON.parse(params)
 }
 
 export function serializeSignMessageParams(params: SignMessageParams) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,10 +238,10 @@
   resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.3.tgz#1cbc269dcd5f29b034cb7f5982353c1cc3629318"
   integrity sha512-cQMy2zanBkVLpmmxXdK6YePzmZx0s5Z7KEnwmrW54rcXK3myCNbQa09SwGZ8i/8sLw0H9F3X7K4rxVNGU8/D4Q==
 
-"@defuse-protocol/defuse-sdk@^1.5.0":
-  version "1.5.0"
-  resolved "https://npm.pkg.github.com/download/@defuse-protocol/defuse-sdk/1.5.0/3ba5feacdc178053fbb48ebf6d7b4aeee911f01c#3ba5feacdc178053fbb48ebf6d7b4aeee911f01c"
-  integrity sha512-9tmW5g1nWiqZWXSpuwpSA78EZc4smcKsTVFpnirIJ569v1mP7fE0XrwB2+q2LgwqnSG5AYzdhYGPZqmq62LoRQ==
+"@defuse-protocol/defuse-sdk@^1.9.0":
+  version "1.9.0"
+  resolved "https://npm.pkg.github.com/download/@defuse-protocol/defuse-sdk/1.9.0/30ba795e90734d43d1033d6826fefb5ae78422b3#30ba795e90734d43d1033d6826fefb5ae78422b3"
+  integrity sha512-Vu6/eQU6/t8gmIY/DDvq6VTVPzg0O7foHkWreVKWgVpH1hyk/cy+DyCIDYQSDV1Q71aRDUxkpPd9UMzhaV9lKg==
   dependencies:
     "@defuse-protocol/swap-facade" "^1.0.3"
     "@radix-ui/react-checkbox" "^1.1.1"
@@ -256,6 +256,7 @@
     axios "^1.7.7"
     clsx "^2.1.1"
     ethers "^6.13.2"
+    qrcode.react "^4.0.1"
     react "^18.3.1"
     react-dom "^18.3.1"
     react-hook-form "^7.52.1"
@@ -10217,6 +10218,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
+qrcode.react@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-4.0.1.tgz#1caf1d3f45bf1b6d9cf800cb0f0d671f6a89e68f"
+  integrity sha512-Lpj0tPBn561WiQ3QQWXbkx8xTtB8BZkJeMZWLJIL8iaPBCoWzW1IpCeU3gY5MDqsb0+efCvEGkl9O0naP64crA==
+
 qrcode@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.5.3.tgz#03afa80912c0dccf12bc93f615a535aad1066170"
@@ -11847,9 +11853,9 @@ verror@1.10.0:
     extsprintf "^1.2.0"
 
 viem@^2.18.1:
-  version "2.21.19"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.19.tgz#5e1a7efc45903d83306416ffa2e3a11ed23cd924"
-  integrity sha512-FdlkN+UI1IU5sYOmzvygkxsUNjDRD5YHht3gZFu2X9xFv6Z3h9pXq9ycrYQ3F17lNfb41O2Ot4/aqbUkwOv9dA==
+  version "2.21.28"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.28.tgz#5823305008ca5c4feb40b6014261fac141c256e2"
+  integrity sha512-CbS2Ldq+SdZYYSG+P4oNLi1s6xq7JnZoJsIkMhFcZUMRz3w2J1OvC1izUp6E1/Zp/XXo3wt6g/Ae+f3SGzup2A==
   dependencies:
     "@adraffy/ens-normalize" "1.11.0"
     "@noble/curves" "1.6.0"
@@ -12433,6 +12439,6 @@ zustand@^4.5.2:
     use-sync-external-store "1.2.2"
 
 zustand@^5.0.0-rc.2:
-  version "5.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.0-rc.2.tgz#d28d95ffb6f0b20cadbaea39210f18446a5bf989"
-  integrity sha512-o2Nwuvnk8vQBX7CcHL8WfFkZNJdxB/VKeWw0tNglw8p4cypsZ3tRT7rTRTDNeUPFS0qaMBRSKe+fVwL5xpcE3A==
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.0.tgz#71f8aaecf185592a3ba2743d7516607361899da9"
+  integrity sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,14 +238,15 @@
   resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.3.tgz#1cbc269dcd5f29b034cb7f5982353c1cc3629318"
   integrity sha512-cQMy2zanBkVLpmmxXdK6YePzmZx0s5Z7KEnwmrW54rcXK3myCNbQa09SwGZ8i/8sLw0H9F3X7K4rxVNGU8/D4Q==
 
-"@defuse-protocol/defuse-sdk@^1.4.0":
-  version "1.4.0"
-  resolved "https://npm.pkg.github.com/download/@defuse-protocol/defuse-sdk/1.4.0/3726d421bc917c2ca5ea5346ba958049573f1fb6#3726d421bc917c2ca5ea5346ba958049573f1fb6"
-  integrity sha512-IcOkTrZYYCxjhK5TKUljOFjL3ajV1EjMAGty/QjfCaTlPIw8RtCMnJf+vUHStNBnToMNdkZvnkXUhaQZkW2XmA==
+"@defuse-protocol/defuse-sdk@^1.5.0":
+  version "1.5.0"
+  resolved "https://npm.pkg.github.com/download/@defuse-protocol/defuse-sdk/1.5.0/3ba5feacdc178053fbb48ebf6d7b4aeee911f01c#3ba5feacdc178053fbb48ebf6d7b4aeee911f01c"
+  integrity sha512-9tmW5g1nWiqZWXSpuwpSA78EZc4smcKsTVFpnirIJ569v1mP7fE0XrwB2+q2LgwqnSG5AYzdhYGPZqmq62LoRQ==
   dependencies:
     "@defuse-protocol/swap-facade" "^1.0.3"
     "@radix-ui/react-checkbox" "^1.1.1"
     "@radix-ui/react-icons" "^1.3.0"
+    "@radix-ui/react-select" "^2.1.2"
     "@radix-ui/react-slot" "^1.1.0"
     "@radix-ui/react-toast" "^1.2.1"
     "@radix-ui/themes" "^3.1.1"
@@ -2931,6 +2932,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.0.tgz#6df8d983546cfd1999c8512f3a8ad85a6e7fcee8"
   integrity sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==
 
+"@radix-ui/react-context@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.1.tgz#82074aa83a472353bb22e86f11bcbd1c61c4c71a"
+  integrity sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==
+
 "@radix-ui/react-dialog@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz#4906507f7b4ad31e22d7dad69d9330c87c431d44"
@@ -2967,6 +2973,17 @@
     "@radix-ui/react-use-callback-ref" "1.1.0"
     "@radix-ui/react-use-escape-keydown" "1.1.0"
 
+"@radix-ui/react-dismissable-layer@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.1.tgz#cbdcb739c5403382bdde5f9243042ba643883396"
+  integrity sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-escape-keydown" "1.1.0"
+
 "@radix-ui/react-dropdown-menu@2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.1.tgz#3dc578488688250dbbe109d9ff2ca28a9bca27ec"
@@ -2984,6 +3001,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz#8e9abb472a9a394f59a1b45f3dd26cfe3fc6da13"
   integrity sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==
+
+"@radix-ui/react-focus-guards@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz#8635edd346304f8b42cae86b05912b61aef27afe"
+  integrity sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==
 
 "@radix-ui/react-focus-scope@1.1.0":
   version "1.1.0"
@@ -3129,6 +3151,14 @@
     "@radix-ui/react-primitive" "2.0.0"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-portal@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.2.tgz#51eb46dae7505074b306ebcb985bf65cc547d74e"
+  integrity sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
 "@radix-ui/react-presence@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.0.tgz#227d84d20ca6bfe7da97104b1a8b48a833bfb478"
@@ -3224,6 +3254,33 @@
     "@radix-ui/react-visually-hidden" "1.1.0"
     aria-hidden "^1.1.1"
     react-remove-scroll "2.5.7"
+
+"@radix-ui/react-select@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-2.1.2.tgz#2346e118966db793940f6a866fd4cc5db2cc275e"
+  integrity sha512-rZJtWmorC7dFRi0owDmoijm6nSJH1tVw64QGiNIZ9PNLyBDtG+iAq+XGsya052At4BfarzY/Dhv9wrrUr6IMZA==
+  dependencies:
+    "@radix-ui/number" "1.1.0"
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-collection" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-dismissable-layer" "1.1.1"
+    "@radix-ui/react-focus-guards" "1.1.1"
+    "@radix-ui/react-focus-scope" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-popper" "1.2.0"
+    "@radix-ui/react-portal" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-slot" "1.1.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+    "@radix-ui/react-use-previous" "1.1.0"
+    "@radix-ui/react-visually-hidden" "1.1.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.6.0"
 
 "@radix-ui/react-slider@1.2.0":
   version "1.2.0"
@@ -10300,7 +10357,7 @@ react-remove-scroll-bar@2.3.4:
     react-style-singleton "^2.2.1"
     tslib "^2.0.0"
 
-react-remove-scroll-bar@^2.3.4:
+react-remove-scroll-bar@^2.3.4, react-remove-scroll-bar@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz#3e585e9d163be84a010180b18721e851ac81a29c"
   integrity sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==
@@ -10314,6 +10371,17 @@ react-remove-scroll@2.5.7:
   integrity sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==
   dependencies:
     react-remove-scroll-bar "^2.3.4"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
+react-remove-scroll@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz#fb03a0845d7768a4f1519a99fdb84983b793dc07"
+  integrity sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==
+  dependencies:
+    react-remove-scroll-bar "^2.3.6"
     react-style-singleton "^2.2.1"
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"


### PR DESCRIPTION
This PR unlocks the deposit page and updates the gateway route for sending specific messages.

Key changes:
- Update routes
- Implement DepositWidget from SDK
- Enhance CSS: `defuse-sdk` styles now override global styles
- Update gateway handlers to support `signAndSendTransaction` wallet flow
- Add implementation for `signAndSendTransactionsInNewWindow`