### PR TITLE
fix: fix getting near public key

### DIFF
--- a/src/app/swap/page.tsx
+++ b/src/app/swap/page.tsx
@@ -9,11 +9,13 @@ import { useNearWalletActions } from "@src/hooks/useNearWalletActions"
 import { useNotificationStore } from "@src/providers/NotificationProvider"
 import { useWalletSelector } from "@src/providers/WalletSelectorProvider"
 import { NotificationType } from "@src/stores/notificationStore"
+import { useNearCurrentAccount } from "@src/utils/myNearWalletAdapter"
 
 export default function Swap() {
   const { accountId } = useWalletSelector()
   const { signMessage } = useNearWalletActions()
   const setNotification = useNotificationStore((state) => state.setNotification)
+  const nearCurrentAccount = useNearCurrentAccount()
 
   return (
     <Paper


### PR DESCRIPTION
"MyNearWallet" does not return public key of connect user. PR tries to address it. Public key is needed for SwapWidget to enable Near users with handles (e.g. foo.near) to interact with protocol.