### PR TITLE
chore: clean up connect modal

### DIFF
--- a/src/components/Wallet/WalletConnections.tsx
+++ b/src/components/Wallet/WalletConnections.tsx
@@ -7,18 +7,12 @@ import React, { useEffect, useState } from "react"
 import { CopyToClipboard } from "react-copy-to-clipboard"
 
 import NetworkIcon from "@src/components/Network/NetworkIcon"
-import {
-  CONNECTOR_BTC_MAINNET,
-  CONNECTOR_ETH_BASE,
-} from "@src/constants/contracts"
 import { ChainType, useConnectWallet } from "@src/hooks/useConnectWallet"
 import useShortAccountId from "@src/hooks/useShortAccountId"
 import { getChainIconFromId } from "@src/hooks/useTokensListAdapter"
 import { MapsEnum } from "@src/libs/de-sdk/utils/maps"
-import { useModalStore } from "@src/providers/ModalStoreProvider"
 import { useTokensStore } from "@src/providers/TokensStoreProvider"
 import { useWalletSelector } from "@src/providers/WalletSelectorProvider"
-import { ModalType } from "@src/stores/modalStore"
 
 type WalletConnectionState = {
   chainIcon: string
@@ -55,7 +49,6 @@ const WalletConnectionsConnector = ({
   const { shortAccountId } = useShortAccountId(accountId ?? "")
   return (
     <div className="flex flex-col justify-between items-center gap-2.5">
-      {!index ? <Separator orientation="horizontal" size="4" /> : <div />}
       <div className="w-full flex justify-between items-center">
         <div className="flex justify-center items-center gap-4">
           <NetworkIcon
@@ -116,22 +109,8 @@ const WalletConnections = () => {
   const { state, signOut } = useConnectWallet()
   const { accountId } = useWalletSelector()
   const [copyWalletAddress, setCopyWalletAddress] = useState<MapsEnum>()
-  const { setModalType } = useModalStore((state) => state)
   const { triggerTokenUpdate } = useTokensStore((state) => state)
   const [isProcessing, setIsProcessing] = useState(false)
-
-  const handleGetConnector = (connectorKey: string): string => {
-    const getWalletFromLocal = localStorage.getItem(connectorKey)
-    if (!getWalletFromLocal) return ""
-    return getWalletFromLocal
-  }
-
-  const handleDisconnectSideWallet = (connectorKey: string) => {
-    localStorage.removeItem(connectorKey)
-    triggerTokenUpdate()
-    // To force a rerender the component we update the state
-    setIsProcessing(true)
-  }
 
   useEffect(() => {
     // Finalize state update after forced re-render
@@ -145,14 +124,10 @@ const WalletConnections = () => {
         weight="medium"
         className="text-gray-600 dark:text-gray-500 pb-2"
       >
-        Connections
+        Connection
       </Text>
       {connections.map((connector, i) => {
-        const defuse_asset_id = ""
         let chainIcon = ""
-        const chainName = ""
-        const accountIdFromLocal = ""
-        const storeKey = ""
         switch (connector) {
           case MapsEnum.NEAR_MAINNET:
             if (state.chainType !== ChainType.Near) {

--- a/src/components/Wallet/index.tsx
+++ b/src/components/Wallet/index.tsx
@@ -12,7 +12,6 @@ import WalletTabs from "@src/components/Wallet/WalletTabs"
 import { ChainType, useConnectWallet } from "@src/hooks/useConnectWallet"
 import useShortAccountId from "@src/hooks/useShortAccountId"
 import { useHistoryStore } from "@src/providers/HistoryStoreProvider"
-import ComingSoon, { LabelComingSoon } from "../ComingSoon"
 
 const TURN_OFF_APPS = process?.env?.turnOffApps === "true" ?? true
 
@@ -137,23 +136,20 @@ const ConnectWallet = () => {
           <div className="flex flex-col gap-5">
             {/* <WalletTabs /> */}
             <WalletConnections />
-            <div className="relative">
-              <ComingSoon className="-top-[1rem]">
-                <Button
-                  onClick={handleTradeHistory}
-                  size="2"
-                  variant="soft"
-                  radius="full"
-                  color="gray"
-                  className="w-full text-black dark:text-white cursor-pointer"
-                >
-                  <CountdownTimerIcon width={16} height={16} />
-                  <Text size="2" weight="medium">
-                    Transactions
-                  </Text>
-                </Button>
-              </ComingSoon>
-            </div>
+            {/* TODO: Transactions button has to be redesigned or removed */}
+            {/* <Button
+              onClick={handleTradeHistory}
+              size="2"
+              variant="soft"
+              radius="full"
+              color="gray"
+              className="w-full text-black dark:text-white cursor-pointer"
+            >
+              <CountdownTimerIcon width={16} height={16} />
+              <Text size="2" weight="medium">
+                Transactions
+              </Text>
+            </Button> */}
           </div>
         </Popover.Content>
       </Popover.Root>


### PR DESCRIPTION
- Remove redundant `transactions` button and make the connect modal more specific
- Delete outdated handlers

Example:
<img width="427" alt="Screenshot 2024-11-07 at 17 47 38" src="https://github.com/user-attachments/assets/e1758730-9db7-410a-912b-dad3543065b0">
