### PR TITLE
feat: Integrate user account and wallet details with Sentry

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,7 @@ import "@near-wallet-selector/modal-ui/styles.css"
 import "@near-wallet-selector/account-export/styles.css"
 import "@defuse-protocol/defuse-sdk/styles"
 import "../styles/global.scss"
+import { SentryTracer } from "@src/components/SentryTracer"
 import { config } from "@src/config/wagmi"
 
 const DEV_MODE = process?.env?.NEXT_PUBLIC_DEV_MODE === "true" ?? false
@@ -58,6 +59,7 @@ const RootLayout = ({
                       </HistoryStoreProvider>
                     </Theme>
                   </ThemeProvider>
+                  <SentryTracer />
                 </WalletSelectorProvider>
                 {DEV_MODE && <ReactQueryDevtools initialIsOpen={false} />}
               </QueryClientProvider>

--- a/src/components/SentryTracer.tsx
+++ b/src/components/SentryTracer.tsx
@@ -1,0 +1,12 @@
+import { useSentrySetContextWallet } from "@src/hooks/useSetSentry"
+
+import { useConnectWallet } from "@src/hooks/useConnectWallet"
+import { useSentrySetUser } from "@src/hooks/useSetSentry"
+
+export const SentryTracer = () => {
+  const { state } = useConnectWallet()
+
+  useSentrySetUser({ userAddress: state.address })
+  useSentrySetContextWallet({ userAddress: state.address })
+  return null
+}

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -1,19 +1,11 @@
 "use client"
 
 import type { FinalExecutionOutcome } from "@near-wallet-selector/core"
-import * as Sentry from "@sentry/nextjs"
 import { useWalletSelector } from "@src/providers/WalletSelectorProvider"
 import type { SignAndSendTransactionsParams } from "@src/types/interfaces"
 import { useEffect, useState } from "react"
-import {
-  type Connector,
-  useAccount,
-  useConnect,
-  useConnectorClient,
-  useDisconnect,
-} from "wagmi"
+import { type Connector, useAccount, useConnect, useDisconnect } from "wagmi"
 import { useNearWalletActions } from "./useNearWalletActions"
-import { useSentrySetContextWallet, useSentrySetUser } from "./useSetSentry"
 
 export enum ChainType {
   Near = "near",
@@ -58,9 +50,6 @@ export const useConnectWallet = (): ConnectWalletAction => {
   const { connectors, connect } = useConnect()
   const { disconnect } = useDisconnect()
   const { address, chain } = useAccount()
-
-  useSentrySetUser({ userAddress: state.address })
-  useSentrySetContextWallet({ userAddress: state.address })
 
   const handleSignInViaNearWalletSelector = async (): Promise<void> => {
     modal.show()

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -1,11 +1,19 @@
 "use client"
 
 import type { FinalExecutionOutcome } from "@near-wallet-selector/core"
+import * as Sentry from "@sentry/nextjs"
 import { useWalletSelector } from "@src/providers/WalletSelectorProvider"
 import type { SignAndSendTransactionsParams } from "@src/types/interfaces"
 import { useEffect, useState } from "react"
-import { type Connector, useAccount, useConnect, useDisconnect } from "wagmi"
+import {
+  type Connector,
+  useAccount,
+  useConnect,
+  useConnectorClient,
+  useDisconnect,
+} from "wagmi"
 import { useNearWalletActions } from "./useNearWalletActions"
+import { useSentrySetContextWallet, useSentrySetUser } from "./useSetSentry"
 
 export enum ChainType {
   Near = "near",
@@ -50,6 +58,9 @@ export const useConnectWallet = (): ConnectWalletAction => {
   const { connectors, connect } = useConnect()
   const { disconnect } = useDisconnect()
   const { address, chain } = useAccount()
+
+  useSentrySetUser({ userAddress: state.address })
+  useSentrySetContextWallet({ userAddress: state.address })
 
   const handleSignInViaNearWalletSelector = async (): Promise<void> => {
     modal.show()

--- a/src/hooks/useSetSentry.ts
+++ b/src/hooks/useSetSentry.ts
@@ -1,10 +1,7 @@
 import { setContext, setUser } from "@sentry/nextjs"
 import { useWalletSelector } from "@src/providers/WalletSelectorProvider"
-import { useCallback, useEffect } from "react"
-import { useConnect, useConnectorClient } from "wagmi"
-
-// We should use custom types as QueryKey from wagmi Array type unknown
-type QueryKey = [string, { chainId: number; connectorUid: string }]
+import { useEffect } from "react"
+import { useAccount } from "wagmi"
 
 export const useSentrySetUser = ({ userAddress }: { userAddress?: string }) => {
   useEffect(() => {
@@ -18,27 +15,13 @@ export const useSentrySetContextWallet = ({
   userAddress,
 }: { userAddress?: string }) => {
   const { selectedWalletId: nearWalletSelector } = useWalletSelector()
-  const { connectors: wagmiConnectors } = useConnect()
-  const wagmiConnectorClient = useConnectorClient()
-
-  const getWagmiConnectorName = useCallback(() => {
-    const queryKey = wagmiConnectorClient.queryKey as QueryKey
-    if (!queryKey || !queryKey[1]) {
-      return null
-    }
-    const connectorUid = queryKey[1].connectorUid
-    const wagmiConnector = wagmiConnectors.find(
-      (connector) => connector.uid === connectorUid
-    )
-    return wagmiConnector?.name
-  }, [wagmiConnectorClient, wagmiConnectors])
+  const { connector } = useAccount()
 
   useEffect(() => {
     if (userAddress) {
       let wallet = null
-      const wagmiConnectorName = getWagmiConnectorName()
-      if (wagmiConnectorName) {
-        wallet = wagmiConnectorName
+      if (connector) {
+        wallet = connector.name
       }
       if (nearWalletSelector) {
         wallet = nearWalletSelector
@@ -47,5 +30,5 @@ export const useSentrySetContextWallet = ({
         setContext("wallet", { wallet })
       }
     }
-  }, [userAddress, nearWalletSelector, getWagmiConnectorName])
+  }, [userAddress, nearWalletSelector, connector])
 }

--- a/src/hooks/useSetSentry.ts
+++ b/src/hooks/useSetSentry.ts
@@ -1,0 +1,51 @@
+import * as Sentry from "@sentry/nextjs"
+import { useWalletSelector } from "@src/providers/WalletSelectorProvider"
+import { useCallback, useEffect } from "react"
+import { useConnect, useConnectorClient } from "wagmi"
+
+// We should use custom types as QueryKey from wagmi Array type unknown
+type QueryKey = [string, { chainId: number; connectorUid: string }]
+
+export const useSentrySetUser = ({ userAddress }: { userAddress?: string }) => {
+  useEffect(() => {
+    if (userAddress) {
+      Sentry.setUser({ id: userAddress })
+    }
+  }, [userAddress])
+}
+
+export const useSentrySetContextWallet = ({
+  userAddress,
+}: { userAddress?: string }) => {
+  const { selectedWalletId: nearWalletSelector } = useWalletSelector()
+  const { connectors: wagmiConnectors } = useConnect()
+  const wagmiConnectorClient = useConnectorClient()
+
+  const getWagmiConnectorName = useCallback(() => {
+    const queryKey = wagmiConnectorClient.queryKey as QueryKey
+    if (!queryKey || !queryKey[1]) {
+      return null
+    }
+    const connectorUid = queryKey[1].connectorUid
+    const wagmiConnector = wagmiConnectors.find(
+      (connector) => connector.uid === connectorUid
+    )
+    return wagmiConnector?.name
+  }, [wagmiConnectorClient, wagmiConnectors])
+
+  useEffect(() => {
+    if (userAddress) {
+      let wallet = null
+      const wagmiConnectorName = getWagmiConnectorName()
+      if (wagmiConnectorName) {
+        wallet = wagmiConnectorName
+      }
+      if (nearWalletSelector) {
+        wallet = nearWalletSelector
+      }
+      if (wallet) {
+        Sentry.setContext("wallet", { wallet })
+      }
+    }
+  }, [userAddress, nearWalletSelector, getWagmiConnectorName])
+}

--- a/src/hooks/useSetSentry.ts
+++ b/src/hooks/useSetSentry.ts
@@ -7,8 +7,7 @@ export const useSentrySetUser = ({ userAddress }: { userAddress?: string }) => {
   useEffect(() => {
     if (userAddress) {
       setUser({ id: userAddress })
-    }
-    return () => {
+    } else {
       setUser(null)
     }
   }, [userAddress])
@@ -32,8 +31,7 @@ export const useSentrySetContextWallet = ({
       if (wallet) {
         setContext("wallet", { wallet })
       }
-    }
-    return () => {
+    } else {
       setContext("wallet", null)
     }
   }, [userAddress, nearWalletSelector, connector])

--- a/src/hooks/useSetSentry.ts
+++ b/src/hooks/useSetSentry.ts
@@ -8,6 +8,9 @@ export const useSentrySetUser = ({ userAddress }: { userAddress?: string }) => {
     if (userAddress) {
       setUser({ id: userAddress })
     }
+    return () => {
+      setUser(null)
+    }
   }, [userAddress])
 }
 
@@ -29,6 +32,9 @@ export const useSentrySetContextWallet = ({
       if (wallet) {
         setContext("wallet", { wallet })
       }
+    }
+    return () => {
+      setContext("wallet", null)
     }
   }, [userAddress, nearWalletSelector, connector])
 }

--- a/src/hooks/useSetSentry.ts
+++ b/src/hooks/useSetSentry.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs"
+import { setContext, setUser } from "@sentry/nextjs"
 import { useWalletSelector } from "@src/providers/WalletSelectorProvider"
 import { useCallback, useEffect } from "react"
 import { useConnect, useConnectorClient } from "wagmi"
@@ -9,7 +9,7 @@ type QueryKey = [string, { chainId: number; connectorUid: string }]
 export const useSentrySetUser = ({ userAddress }: { userAddress?: string }) => {
   useEffect(() => {
     if (userAddress) {
-      Sentry.setUser({ id: userAddress })
+      setUser({ id: userAddress })
     }
   }, [userAddress])
 }
@@ -44,7 +44,7 @@ export const useSentrySetContextWallet = ({
         wallet = nearWalletSelector
       }
       if (wallet) {
-        Sentry.setContext("wallet", { wallet })
+        setContext("wallet", { wallet })
       }
     }
   }, [userAddress, nearWalletSelector, getWagmiConnectorName])

--- a/src/providers/WalletSelectorProvider.tsx
+++ b/src/providers/WalletSelectorProvider.tsx
@@ -52,6 +52,7 @@ interface WalletSelectorContextValue {
   modal: WalletSelectorModal
   accounts: Array<AccountState>
   accountId: string | null
+  selectedWalletId: string | null
 }
 
 const NEAR_ENV = process.env.NEAR_ENV ?? "testnet"
@@ -175,6 +176,7 @@ export const WalletSelectorProvider: React.FC<{
       modal: modal!,
       accounts,
       accountId: accounts.find((account) => account.active)?.accountId || null,
+      selectedWalletId: selector?.store.getState().selectedWalletId || null,
     }),
     [selector, modal, accounts]
   )


### PR DESCRIPTION
- Capture and send user account ID and wallet name to Sentry for enhanced traceability
- Utilize `useSentrySetContextWallet` to identify wallet names across different providers, such as MyNearWallet and Coinbase Wallet, using wallet UID