### PR TITLE
fix: Phantom wallet switches to EVM address

### DIFF
--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -134,6 +134,15 @@ export const useConnectWallet = (): ConnectWalletAction => {
     }
   }
 
+  /**
+   * Ensure Solana Wallet state overrides EVM Wallet state:
+   * Context:
+   *   Phantom Wallet supports both Solana and EVM chains.
+   * Issue:
+   *   When Phantom Wallet connects, it may emit an EVM connection event.
+   *   This causes `wagmi` to connect to the EVM chain, leading to unexpected
+   *   address switching. Placing Solana Wallet state last prevents this.
+   */
   if (solanaWallet.publicKey != null) {
     state = {
       address: solanaWallet.publicKey.toBase58(),

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -13,7 +13,7 @@ import type {
   SignAndSendTransactionsParams,
 } from "@src/types/interfaces"
 import type { SendTransactionParameters } from "@wagmi/core"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect } from "react"
 import { type Connector, useAccount, useConnect, useDisconnect } from "wagmi"
 import { useEVMWalletActions } from "./useEVMWalletActions"
 import { useNearWalletActions } from "./useNearWalletActions"
@@ -57,7 +57,7 @@ const NEXT_PUBLIC_SOLANA_ENABLED =
   process?.env?.NEXT_PUBLIC_SOLANA_ENABLED === "true"
 
 export const useConnectWallet = (): ConnectWalletAction => {
-  const [state, setState] = useState<State>(defaultState)
+  let state: State = defaultState
 
   /**
    * NEAR:
@@ -116,46 +116,31 @@ export const useConnectWallet = (): ConnectWalletAction => {
     await solanaWallet.disconnect()
   }, [solanaWallet])
 
-  /**
-   * Set the state based on the current wallet connection.
-   * All wallets connection should be handled here.
-   */
-  useEffect(() => {
-    if (
-      !nearWallet.accountId &&
-      !evmWalletAccount.address &&
-      !solanaWallet.publicKey
-    ) {
-      // Reset the state if all wallets are disconnected
-      return setState(defaultState)
+  if (nearWallet.accountId != null) {
+    state = {
+      address: nearWallet.accountId,
+      network: "near:mainnet",
+      chainType: ChainType.Near,
     }
-    if (nearWallet.accountId != null) {
-      setState({
-        address: nearWallet.accountId,
-        network: "near:mainnet",
-        chainType: ChainType.Near,
-      })
-    } else if (evmWalletAccount.address != null && evmWalletAccount.chain) {
-      setState({
-        address: evmWalletAccount.address,
-        network: evmWalletAccount.chain.id
-          ? `eth:${evmWalletAccount.chain.id}`
-          : "unknown",
-        chainType: ChainType.EVM,
-      })
-    } else if (solanaWallet.publicKey != null) {
-      setState({
-        address: solanaWallet.publicKey.toBase58(),
-        network: "sol:mainnet",
-        chainType: ChainType.Solana,
-      })
+  }
+
+  if (evmWalletAccount.address != null && evmWalletAccount.chain) {
+    state = {
+      address: evmWalletAccount.address,
+      network: evmWalletAccount.chain.id
+        ? `eth:${evmWalletAccount.chain.id}`
+        : "unknown",
+      chainType: ChainType.EVM,
     }
-  }, [
-    nearWallet.accountId,
-    evmWalletAccount.address,
-    evmWalletAccount.chain,
-    solanaWallet.publicKey,
-  ])
+  }
+
+  if (solanaWallet.publicKey != null) {
+    state = {
+      address: solanaWallet.publicKey.toBase58(),
+      network: "sol:mainnet",
+      chainType: ChainType.Solana,
+    }
+  }
 
   /**
    * This hook is used to disconnect the wallet under the feature flag is off


### PR DESCRIPTION
# Problem
 
Sometimes Phantom decides to connect an EVM address too. So `wagmi`, being a good library, connects Phantom. As a result user sees their EVM address, but not Solana address.

# Solution

I considered a few approaches:

1. Save the last connection type (EVM, Solana, Near) to `localStorage` and use it to determine `state`. 
2. Disable wagmi when Solana is connected

All these approaches looked clunky and fragile with own bag of bugs.

So I found more straight forward solution, just override `state` variable. This works because Solana wallet goes last and overrides EVM wallet. Such approach will work as long as we don't have an EVM wallet that supports Solana and it doesn't have similar weird approach of connecting to chain that nobody asked them to.

