### PR TITLE
refactor: simplify switching themes

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -19,7 +19,6 @@ NEXT_PUBLIC_LINK_DISCORD="https://discord.gg/rdGAgDRs"
 NEXT_PUBLIC_LINK_DOCS="https://docs.google.com/document/d/1yK5zjZpdA8IjiGc3JSzb7dfyt-5qsBjMMMi4KbYNHkM/edit?usp=sharing"
 NEXT_PUBLIC_PUBLIC_TG="https://t.me/near_intents"
 NEXT_PUBLIC_DEV_MODE=false
-NEXT_PUBLIC_DARK_MODE=false
 FLAGS_SECRET="dont_care"
 
 ######################################################

--- a/.env.production
+++ b/.env.production
@@ -14,7 +14,6 @@ NEXT_PUBLIC_LINK_X="https://x.com/DefuseProtocol"
 NEXT_PUBLIC_LINK_DISCORD="https://discord.gg/rdGAgDRs"
 NEXT_PUBLIC_LINK_DOCS="https://docs.google.com/document/d/1yK5zjZpdA8IjiGc3JSzb7dfyt-5qsBjMMMi4KbYNHkM/edit?usp=sharing"
 NEXT_PUBLIC_PUBLIC_TG="https://t.me/near_intents"
-NEXT_PUBLIC_DARK_MODE=false
 
 ######################################################
 # Feature Flags                                      #

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,7 +1,5 @@
 "use client"
 
-import { useEffect } from "react"
-
 import Banner from "@src/app/landing/Banner"
 import CardSocial from "@src/app/landing/Card/CardSocial"
 import Evolution from "@src/app/landing/Evolution"
@@ -13,17 +11,12 @@ import TryDefuse from "@src/app/landing/TryDefuse"
 // import InvestorLogo from "@src/app/landing/InvestorLogo"
 import Vision from "@src/app/landing/Vision"
 import { settings } from "@src/config/settings"
-import { THEME_MODE_KEY } from "@src/constants/contracts"
 
 const SOCIAL_LINK_X = process?.env?.socialX ?? ""
 const SOCIAL_LINK_DISCORD = process?.env?.socialDiscord ?? ""
 const LINK_DOCS = process?.env?.socialDocs ?? ""
 
 export default function Home() {
-  useEffect(() => {
-    localStorage.setItem(THEME_MODE_KEY, "light")
-  }, [])
-
   return (
     <div className="flex flex-col flex-1 justify-start item-center">
       <Banner />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,42 +6,35 @@ import { Theme } from "@radix-ui/themes"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { ThemeProvider } from "next-themes"
-import { useEffect } from "react"
+import type { ReactNode } from "react"
+import { WagmiProvider } from "wagmi"
 
 import Modal from "@src/components/Modal"
+import { SentryTracer } from "@src/components/SentryTracer"
+import { config } from "@src/config/wagmi"
 import queryClient from "@src/constants/queryClient"
 import { HistoryStoreProvider } from "@src/providers/HistoryStoreProvider"
 import { ModalStoreProvider } from "@src/providers/ModalStoreProvider"
 import { NotificationStoreProvider } from "@src/providers/NotificationProvider"
+import { SolanaWalletProvider } from "@src/providers/SolanaWalletProvider"
 import { TokensStoreProvider } from "@src/providers/TokensStoreProvider"
 import { WalletSelectorProvider } from "@src/providers/WalletSelectorProvider"
-import { WagmiProvider } from "wagmi"
+
 import "@radix-ui/themes/styles.css"
 import "@near-wallet-selector/modal-ui/styles.css"
 import "@near-wallet-selector/account-export/styles.css"
 import "@defuse-protocol/defuse-sdk/styles"
 import "../styles/global.scss"
-import { SentryTracer } from "@src/components/SentryTracer"
-import { config } from "@src/config/wagmi"
-import { SolanaWalletProvider } from "@src/providers/SolanaWalletProvider"
 
 const DEV_MODE = process?.env?.NEXT_PUBLIC_DEV_MODE === "true" ?? false
-const DARK_MODE_ENABLED =
-  process?.env?.NEXT_PUBLIC_DARK_MODE === "true" ?? false
 
 const RootLayout = ({
   children,
 }: Readonly<{
-  children?: React.ReactNode
+  children?: ReactNode
 }>) => {
-  // CONTEXT: Could be used to share global concerns, theme
-  //          like the current theme etc.
-  useEffect(() => {
-    localStorage.setItem("theme", DARK_MODE_ENABLED ? "dark" : "light")
-  }, [])
-
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body>
         <WagmiProvider config={config}>
           <SwapWidgetProvider>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,11 +1,9 @@
 "use client"
 
 import { ExternalLinkIcon } from "@radix-ui/react-icons"
-import { Popover, Separator, Spinner, Switch, Text } from "@radix-ui/themes"
+import { Popover, Separator, Switch, Text } from "@radix-ui/themes"
 import { useTheme } from "next-themes"
-import React, { useState, useEffect } from "react"
 
-import { THEME_MODE_KEY } from "@src/constants/contracts"
 import Themes from "@src/types/themes"
 import ComingSoon from "./ComingSoon"
 import LabelNew from "./LabelNew"
@@ -13,8 +11,6 @@ import LabelNew from "./LabelNew"
 const NEXT_PUBLIC_LINK_DOCS = process.env.NEXT_PUBLIC_LINK_DOCS ?? ""
 const NEXT_PUBLIC_PUBLIC_MAIL = process?.env?.NEXT_PUBLIC_PUBLIC_MAIL ?? ""
 const NEXT_PUBLIC_PUBLIC_TG = process?.env?.NEXT_PUBLIC_PUBLIC_TG ?? ""
-const DARK_MODE_ENABLED =
-  process?.env?.NEXT_PUBLIC_DARK_MODE === "true" ?? false
 
 const Settings = () => {
   const elementCircleStyle =
@@ -91,23 +87,8 @@ const Settings = () => {
 
 const DarkMode = () => {
   const { theme, setTheme } = useTheme()
-  const onChangeTheme = () => {
-    setTheme(theme === Themes.DARK ? Themes.LIGHT : Themes.DARK)
-  }
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <reason>
-  useEffect(() => {
-    const getThemeFromLocal = localStorage.getItem(THEME_MODE_KEY)
-    if (!getThemeFromLocal) {
-      setTheme(Themes.LIGHT)
-      return
-    }
-    if (getThemeFromLocal === "light" || getThemeFromLocal === "dark") {
-      setTheme(getThemeFromLocal)
-    }
-  }, [])
-
-  const DarkModeSwitch = (
+  const darkModeSwitch = (
     <div className="flex justify-between items-center gap-4">
       <Text size="2" weight="medium">
         Dark Mode
@@ -115,18 +96,16 @@ const DarkMode = () => {
       <Switch
         className="cursor-pointer"
         size="1"
-        onClick={onChangeTheme}
+        onCheckedChange={(checked: boolean) => {
+          setTheme(checked ? Themes.DARK : Themes.LIGHT)
+        }}
         color="orange"
         defaultChecked={theme === Themes.DARK}
       />
     </div>
   )
 
-  return DARK_MODE_ENABLED ? (
-    DarkModeSwitch
-  ) : (
-    <ComingSoon className="top-[0.25rem]">{DarkModeSwitch}</ComingSoon>
-  )
+  return <ComingSoon className="top-[0.25rem]">{darkModeSwitch}</ComingSoon>
 }
 
 export default Settings

--- a/src/constants/contracts.ts
+++ b/src/constants/contracts.ts
@@ -35,6 +35,4 @@ export const CONNECTOR_BTC_MAINNET = "__d_btc_mainnet_connector"
 export const CREATE_INTENT_EXPIRATION_BLOCK_BOOST = 350
 export const CREATE_INTENT_ROLLBACK_DELAY = 90
 
-export const THEME_MODE_KEY = "theme"
-
 export const PRECISION = 10 ** 24 // In 24 decimals


### PR DESCRIPTION
We don't need tracking theme in storage, because the `next-themes` already does that for us.