### PR TITLE
fix: flatten wallet details

### DIFF
--- a/src/hooks/useSetSentry.ts
+++ b/src/hooks/useSetSentry.ts
@@ -62,11 +62,9 @@ export const useSentrySetUser = () => {
 
       return {
         id: userConnectionState.address,
-        wallet: {
-          blockchainType: userConnectionState.chainType,
-          walletProvider,
-          walletAppName,
-        },
+        walletChainType: userConnectionState.chainType,
+        walletProvider,
+        walletAppName,
       }
     }
   }, [selector.wallet, connector, solanaWallet, userConnectionState])


### PR DESCRIPTION
Having a wallet object does not allow to search against it.