### PR TITLE
feature: Add Privacy Policy + Terms and Conditions pages

### DIFF
--- a/public/static/documents/privacy-policy.html
+++ b/public/static/documents/privacy-policy.html
@@ -1,0 +1,4952 @@
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="content-type" />
+    <style type="text/css">
+      @import url(https://themes.googleusercontent.com/fonts/css?kit=fpjTOVmNbO4Lz34iLyptLUXza5VhXqVC6o75Eld_V98);
+      .lst-kix_list_2-1 > li {
+        counter-increment: lst-ctn-kix_list_2-1;
+      }
+      .lst-kix_list_5-0 > li {
+        counter-increment: lst-ctn-kix_list_5-0;
+      }
+      ol.lst-kix_list_2-3.start {
+        counter-reset: lst-ctn-kix_list_2-3 0;
+      }
+      ol.lst-kix_list_5-3.start {
+        counter-reset: lst-ctn-kix_list_5-3 0;
+      }
+      .lst-kix_list_4-3 > li {
+        counter-increment: lst-ctn-kix_list_4-3;
+      }
+      .lst-kix_fnj7klr0wrov-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_jpvy5hdtq2p3-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_jpvy5hdtq2p3-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_jpvy5hdtq2p3-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_jpvy5hdtq2p3-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_jpvy5hdtq2p3-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_coaitzo8e22o-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_jpvy5hdtq2p3-1 {
+        list-style-type: none;
+      }
+      .lst-kix_list_1-4 > li {
+        counter-increment: lst-ctn-kix_list_1-4;
+      }
+      ul.lst-kix_coaitzo8e22o-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_jpvy5hdtq2p3-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_coaitzo8e22o-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_jpvy5hdtq2p3-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_1-6.start {
+        counter-reset: lst-ctn-kix_list_1-6 0;
+      }
+      ul.lst-kix_coaitzo8e22o-3 {
+        list-style-type: none;
+      }
+      .lst-kix_fnj7klr0wrov-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_fnj7klr0wrov-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_fnj7klr0wrov-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_fnj7klr0wrov-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_fnj7klr0wrov-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_coaitzo8e22o-4 {
+        list-style-type: none;
+      }
+      .lst-kix_fnj7klr0wrov-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_coaitzo8e22o-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_jpvy5hdtq2p3-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_coaitzo8e22o-6 {
+        list-style-type: none;
+      }
+      .lst-kix_fnj7klr0wrov-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_coaitzo8e22o-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_coaitzo8e22o-8 {
+        list-style-type: none;
+      }
+      .lst-kix_fnj7klr0wrov-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_coaitzo8e22o-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_6-5 > li {
+        counter-increment: lst-ctn-kix_list_6-5;
+      }
+      .lst-kix_coaitzo8e22o-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_coaitzo8e22o-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_list_3-6 > li {
+        counter-increment: lst-ctn-kix_list_3-6;
+      }
+      .lst-kix_coaitzo8e22o-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_afzuvuipsb6i-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_afzuvuipsb6i-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_afzuvuipsb6i-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_afzuvuipsb6i-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_afzuvuipsb6i-4 {
+        list-style-type: none;
+      }
+      .lst-kix_list_2-8 > li {
+        counter-increment: lst-ctn-kix_list_2-8;
+      }
+      ul.lst-kix_afzuvuipsb6i-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_afzuvuipsb6i-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_afzuvuipsb6i-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_afzuvuipsb6i-0 {
+        list-style-type: none;
+      }
+      .lst-kix_5uyckpqard-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_1qzjyx1qg1iy-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_z4hxpql0fcdo-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_t9ho1a2xas7j-3 {
+        list-style-type: none;
+      }
+      .lst-kix_ew66vvnubm3e-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_t9ho1a2xas7j-2 {
+        list-style-type: none;
+      }
+      .lst-kix_fvrr9fv4o79b-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_t9ho1a2xas7j-5 {
+        list-style-type: none;
+      }
+      .lst-kix_5uyckpqard-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_5uyckpqard-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_1qzjyx1qg1iy-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_1qzjyx1qg1iy-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_t9ho1a2xas7j-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_4-6.start {
+        counter-reset: lst-ctn-kix_list_4-6 0;
+      }
+      ul.lst-kix_t9ho1a2xas7j-7 {
+        list-style-type: none;
+      }
+      .lst-kix_ew66vvnubm3e-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_t9ho1a2xas7j-6 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_3-0.start {
+        counter-reset: lst-ctn-kix_list_3-0 0;
+      }
+      ul.lst-kix_t9ho1a2xas7j-8 {
+        list-style-type: none;
+      }
+      .lst-kix_list_5-7 > li {
+        counter-increment: lst-ctn-kix_list_5-7;
+      }
+      .lst-kix_fvrr9fv4o79b-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_fvrr9fv4o79b-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_5uyckpqard-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_t9ho1a2xas7j-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_t9ho1a2xas7j-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5uyckpqard-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5uyckpqard-7 {
+        list-style-type: none;
+      }
+      .lst-kix_coaitzo8e22o-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_5uyckpqard-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5uyckpqard-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5uyckpqard-2 {
+        list-style-type: none;
+      }
+      .lst-kix_ew66vvnubm3e-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_5uyckpqard-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5uyckpqard-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5uyckpqard-1 {
+        list-style-type: none;
+      }
+      .lst-kix_ew66vvnubm3e-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_5uyckpqard-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_coaitzo8e22o-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_5uyckpqard-8 {
+        list-style-type: none;
+      }
+      .lst-kix_8dk1wnpc6r4-5 > li {
+        counter-increment: lst-ctn-kix_8dk1wnpc6r4-5;
+      }
+      .lst-kix_list_3-5 > li {
+        counter-increment: lst-ctn-kix_list_3-5;
+      }
+      ol.lst-kix_list_1-1.start {
+        counter-reset: lst-ctn-kix_list_1-1 0;
+      }
+      .lst-kix_1qzjyx1qg1iy-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_zc802926avdh-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_tn1l1rlq5s7-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_eqlaut7noayk-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_6-4 > li {
+        counter-increment: lst-ctn-kix_list_6-4;
+      }
+      .lst-kix_tn1l1rlq5s7-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_zc802926avdh-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_tn1l1rlq5s7-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_2-8.start {
+        counter-reset: lst-ctn-kix_list_2-8 0;
+      }
+      .lst-kix_eqlaut7noayk-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_zc802926avdh-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_eqlaut7noayk-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_tn1l1rlq5s7-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ol.lst-kix_list_5-8.start {
+        counter-reset: lst-ctn-kix_list_5-8 0;
+      }
+      .lst-kix_list_1-3 > li {
+        counter-increment: lst-ctn-kix_list_1-3;
+      }
+      .lst-kix_z4hxpql0fcdo-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_6-0.start {
+        counter-reset: lst-ctn-kix_list_6-0 0;
+      }
+      .lst-kix_z4hxpql0fcdo-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_zc802926avdh-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_z4hxpql0fcdo-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_4-2 > li {
+        counter-increment: lst-ctn-kix_list_4-2;
+      }
+      ol.lst-kix_list_3-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_wwx8zpyq2pae-7 {
+        list-style-type: none;
+      }
+      .lst-kix_7gcceflsf6k0-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_n81gzgxe38yj-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_3-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_wwx8zpyq2pae-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_3-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_3-4.start {
+        counter-reset: lst-ctn-kix_list_3-4 0;
+      }
+      ul.lst-kix_wwx8zpyq2pae-5 {
+        list-style-type: none;
+      }
+      .lst-kix_list_5-1 > li {
+        counter-increment: lst-ctn-kix_list_5-1;
+      }
+      ol.lst-kix_list_3-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_wwx8zpyq2pae-6 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8dk1wnpc6r4-8.start {
+        counter-reset: lst-ctn-kix_8dk1wnpc6r4-8 0;
+      }
+      ul.lst-kix_wwx8zpyq2pae-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_f9961645pj1n-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_wwx8zpyq2pae-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_f9961645pj1n-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_wwx8zpyq2pae-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_f9961645pj1n-2 {
+        list-style-type: none;
+      }
+      .lst-kix_7gcceflsf6k0-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_7gcceflsf6k0-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ol.lst-kix_list_3-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_wwx8zpyq2pae-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_f9961645pj1n-3 {
+        list-style-type: none;
+      }
+      .lst-kix_7gcceflsf6k0-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_tf0geodn37sd-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_tf0geodn37sd-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_tf0geodn37sd-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_e5mhrzfnma4q-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_7gcceflsf6k0-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_f9961645pj1n-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_wwx8zpyq2pae-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_f9961645pj1n-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_f9961645pj1n-6 {
+        list-style-type: none;
+      }
+      .lst-kix_e5mhrzfnma4q-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_f9961645pj1n-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_3-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_f9961645pj1n-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_3-6 {
+        list-style-type: none;
+      }
+      .lst-kix_tf0geodn37sd-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_3-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_3-8 {
+        list-style-type: none;
+      }
+      .lst-kix_z0lw2b2aattg-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_z0lw2b2aattg-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_nszccrumx3wm-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_khiuhskpdykq-5 {
+        list-style-type: none;
+      }
+      .lst-kix_afzuvuipsb6i-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_khiuhskpdykq-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_khiuhskpdykq-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_khiuhskpdykq-8 {
+        list-style-type: none;
+      }
+      .lst-kix_nszccrumx3wm-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_khiuhskpdykq-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_khiuhskpdykq-2 {
+        list-style-type: none;
+      }
+      .lst-kix_z0lw2b2aattg-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_5bxzw67pmq0j-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_khiuhskpdykq-3 {
+        list-style-type: none;
+      }
+      .lst-kix_afzuvuipsb6i-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_khiuhskpdykq-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_khiuhskpdykq-0 {
+        list-style-type: none;
+      }
+      .lst-kix_n81gzgxe38yj-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_5bxzw67pmq0j-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_eqlaut7noayk-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_eqlaut7noayk-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_e5mhrzfnma4q-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_n81gzgxe38yj-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_afzuvuipsb6i-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_e5mhrzfnma4q-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_afzuvuipsb6i-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_5bxzw67pmq0j-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_5bxzw67pmq0j-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_nszccrumx3wm-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_n81gzgxe38yj-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_z0lw2b2aattg-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_n81gzgxe38yj-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_nszccrumx3wm-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_88zd2c7m8zo2-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_88zd2c7m8zo2-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_xwvuqm5td0w4-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_xwvuqm5td0w4-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_xwvuqm5td0w4-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_u42wn2pu9hhe-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_xwvuqm5td0w4-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_88zd2c7m8zo2-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_xwvuqm5td0w4-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_88zd2c7m8zo2-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_8dk1wnpc6r4-2.start {
+        counter-reset: lst-ctn-kix_8dk1wnpc6r4-2 0;
+      }
+      .lst-kix_t9ho1a2xas7j-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_8dk1wnpc6r4-7.start {
+        counter-reset: lst-ctn-kix_8dk1wnpc6r4-7 0;
+      }
+      .lst-kix_fvrr9fv4o79b-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_u42wn2pu9hhe-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_1roqjrv0u415-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_u42wn2pu9hhe-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_fvrr9fv4o79b-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_1roqjrv0u415-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_list_2-2 > li {
+        counter-increment: lst-ctn-kix_list_2-2;
+      }
+      .lst-kix_u42wn2pu9hhe-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_4-7.start {
+        counter-reset: lst-ctn-kix_list_4-7 0;
+      }
+      ul.lst-kix_5ridsspeuiks-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_5-0 {
+        list-style-type: none;
+      }
+      .lst-kix_list_3-7 > li {
+        counter-increment: lst-ctn-kix_list_3-7;
+      }
+      ul.lst-kix_5ridsspeuiks-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_5-1 {
+        list-style-type: none;
+      }
+      .lst-kix_1roqjrv0u415-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_5ridsspeuiks-6 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_5-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5ridsspeuiks-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5ridsspeuiks-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5ridsspeuiks-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5ridsspeuiks-2 {
+        list-style-type: none;
+      }
+      .lst-kix_1qzjyx1qg1iy-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_5ridsspeuiks-3 {
+        list-style-type: none;
+      }
+      .lst-kix_z4hxpql0fcdo-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_list_6-6 > li {
+        counter-increment: lst-ctn-kix_list_6-6;
+      }
+      .lst-kix_1roqjrv0u415-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_ew66vvnubm3e-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_ew66vvnubm3e-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_5uyckpqard-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_5uyckpqard-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_1qzjyx1qg1iy-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_5-7 {
+        list-style-type: none;
+      }
+      .lst-kix_fvrr9fv4o79b-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ol.lst-kix_list_5-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_5-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5ridsspeuiks-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_5-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_5-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_5-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tf0geodn37sd-2 {
+        list-style-type: none;
+      }
+      .lst-kix_coaitzo8e22o-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_tf0geodn37sd-1 {
+        list-style-type: none;
+      }
+      .lst-kix_ew66vvnubm3e-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_tf0geodn37sd-0 {
+        list-style-type: none;
+      }
+      .lst-kix_t9ho1a2xas7j-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_tf0geodn37sd-6 {
+        list-style-type: none;
+      }
+      .lst-kix_list_5-8 > li {
+        counter-increment: lst-ctn-kix_list_5-8;
+      }
+      ul.lst-kix_tf0geodn37sd-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tf0geodn37sd-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tf0geodn37sd-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_21mtbyoilxak-0 {
+        list-style-type: none;
+      }
+      .lst-kix_coaitzo8e22o-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_21mtbyoilxak-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_21mtbyoilxak-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tf0geodn37sd-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_21mtbyoilxak-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tf0geodn37sd-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_2-2.start {
+        counter-reset: lst-ctn-kix_list_2-2 0;
+      }
+      ul.lst-kix_21mtbyoilxak-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_21mtbyoilxak-4 {
+        list-style-type: none;
+      }
+      .lst-kix_t9ho1a2xas7j-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_21mtbyoilxak-5 {
+        list-style-type: none;
+      }
+      .lst-kix_21mtbyoilxak-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_21mtbyoilxak-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_21mtbyoilxak-7 {
+        list-style-type: none;
+      }
+      .lst-kix_ys3df5ypy70p-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_tn1l1rlq5s7-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_tn1l1rlq5s7-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_zc802926avdh-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_zc802926avdh-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_8dk1wnpc6r4-3.start {
+        counter-reset: lst-ctn-kix_8dk1wnpc6r4-3 0;
+      }
+      .lst-kix_ys3df5ypy70p-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_eqlaut7noayk-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_6zv4pkv0v950-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6zv4pkv0v950-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6zv4pkv0v950-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6zv4pkv0v950-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_3-5.start {
+        counter-reset: lst-ctn-kix_list_3-5 0;
+      }
+      .lst-kix_8dk1wnpc6r4-7 > li {
+        counter-increment: lst-ctn-kix_8dk1wnpc6r4-7;
+      }
+      ul.lst-kix_6zv4pkv0v950-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5k4kxq3iqk93-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5k4kxq3iqk93-1 {
+        list-style-type: none;
+      }
+      .lst-kix_z4hxpql0fcdo-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_5k4kxq3iqk93-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5k4kxq3iqk93-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6zv4pkv0v950-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5k4kxq3iqk93-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6zv4pkv0v950-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5k4kxq3iqk93-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6zv4pkv0v950-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5k4kxq3iqk93-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6zv4pkv0v950-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5k4kxq3iqk93-7 {
+        list-style-type: none;
+      }
+      .lst-kix_z4hxpql0fcdo-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_hrjx4g46ence-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_tn1l1rlq5s7-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_5k4kxq3iqk93-0 {
+        list-style-type: none;
+      }
+      .lst-kix_list_4-1 > li {
+        counter-increment: lst-ctn-kix_list_4-1;
+      }
+      ul.lst-kix_vhc5oluvxxf3-3 {
+        list-style-type: none;
+      }
+      .lst-kix_hrjx4g46ence-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_vhc5oluvxxf3-2 {
+        list-style-type: none;
+      }
+      .lst-kix_ipq87akvuv4n-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_vhc5oluvxxf3-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_vhc5oluvxxf3-4 {
+        list-style-type: none;
+      }
+      .lst-kix_hrjx4g46ence-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_vhc5oluvxxf3-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_vhc5oluvxxf3-6 {
+        list-style-type: none;
+      }
+      .lst-kix_ipq87akvuv4n-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_vhc5oluvxxf3-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u42wn2pu9hhe-3 {
+        list-style-type: none;
+      }
+      .lst-kix_ipq87akvuv4n-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_u42wn2pu9hhe-2 {
+        list-style-type: none;
+      }
+      .lst-kix_hrjx4g46ence-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_u42wn2pu9hhe-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u42wn2pu9hhe-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u42wn2pu9hhe-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u42wn2pu9hhe-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u42wn2pu9hhe-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u42wn2pu9hhe-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_6-6.start {
+        counter-reset: lst-ctn-kix_list_6-6 0;
+      }
+      .lst-kix_5grxh0nlok2c-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ol.lst-kix_list_1-5.start {
+        counter-reset: lst-ctn-kix_list_1-5 0;
+      }
+      ul.lst-kix_vhc5oluvxxf3-1 {
+        list-style-type: none;
+      }
+      .lst-kix_f9961645pj1n-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_vhc5oluvxxf3-0 {
+        list-style-type: none;
+      }
+      .lst-kix_8dk1wnpc6r4-2 > li:before {
+        content: "" counter(lst-ctn-kix_8dk1wnpc6r4-2, lower-roman) ". ";
+      }
+      .lst-kix_f9961645pj1n-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_8dk1wnpc6r4-1 > li:before {
+        content: "" counter(lst-ctn-kix_8dk1wnpc6r4-1, lower-latin) ". ";
+      }
+      ol.lst-kix_list_4-5.start {
+        counter-reset: lst-ctn-kix_list_4-5 0;
+      }
+      .lst-kix_f9961645pj1n-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_8dk1wnpc6r4-7 > li:before {
+        content: "" counter(lst-ctn-kix_8dk1wnpc6r4-7, lower-latin) ". ";
+      }
+      .lst-kix_5grxh0nlok2c-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_u42wn2pu9hhe-8 {
+        list-style-type: none;
+      }
+      .lst-kix_gzdocpm58hz7-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_ipq87akvuv4n-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_ipq87akvuv4n-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_gzdocpm58hz7-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_f9961645pj1n-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_5-2 > li {
+        counter-increment: lst-ctn-kix_list_5-2;
+      }
+      .lst-kix_5grxh0nlok2c-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_8dk1wnpc6r4-4 > li:before {
+        content: "" counter(lst-ctn-kix_8dk1wnpc6r4-4, lower-latin) ". ";
+      }
+      .lst-kix_5grxh0nlok2c-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_gzdocpm58hz7-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_f9961645pj1n-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_23dxydqlwhcr-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_23dxydqlwhcr-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_23dxydqlwhcr-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_gzdocpm58hz7-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_23dxydqlwhcr-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_lv1czupk32gw-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_khiuhskpdykq-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_khiuhskpdykq-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_21mtbyoilxak-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_wwx8zpyq2pae-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_wwx8zpyq2pae-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_74jv55lx6o4a-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_m6fvupggs9zx-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_lv1czupk32gw-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_wwx8zpyq2pae-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_74jv55lx6o4a-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_lv1czupk32gw-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_wwx8zpyq2pae-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_21mtbyoilxak-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_74jv55lx6o4a-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_lv1czupk32gw-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_m6fvupggs9zx-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_1-0.start {
+        counter-reset: lst-ctn-kix_list_1-0 0;
+      }
+      .lst-kix_m6fvupggs9zx-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_list_3-0 > li {
+        counter-increment: lst-ctn-kix_list_3-0;
+      }
+      ol.lst-kix_list_4-0.start {
+        counter-reset: lst-ctn-kix_list_4-0 0;
+      }
+      .lst-kix_m6fvupggs9zx-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_khiuhskpdykq-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_khiuhskpdykq-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_m6fvupggs9zx-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_1roqjrv0u415-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_6zv4pkv0v950-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_8dk1wnpc6r4-1.start {
+        counter-reset: lst-ctn-kix_8dk1wnpc6r4-1 0;
+      }
+      .lst-kix_6zv4pkv0v950-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_n2t739nhbi13-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_6zv4pkv0v950-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_4-3.start {
+        counter-reset: lst-ctn-kix_list_4-3 0;
+      }
+      .lst-kix_n2t739nhbi13-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_t9ho1a2xas7j-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_t9ho1a2xas7j-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_21mtbyoilxak-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_list_5-5 > li {
+        counter-increment: lst-ctn-kix_list_5-5;
+      }
+      ul.lst-kix_74jv55lx6o4a-7 {
+        list-style-type: none;
+      }
+      .lst-kix_ys3df5ypy70p-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_74jv55lx6o4a-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_74jv55lx6o4a-8 {
+        list-style-type: none;
+      }
+      .lst-kix_mcion8kv1fq2-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_mcion8kv1fq2-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_6-3 > li {
+        counter-increment: lst-ctn-kix_list_6-3;
+      }
+      .lst-kix_ys3df5ypy70p-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_1-3.start {
+        counter-reset: lst-ctn-kix_list_1-3 0;
+      }
+      ol.lst-kix_list_1-2.start {
+        counter-reset: lst-ctn-kix_list_1-2 0;
+      }
+      .lst-kix_ys3df5ypy70p-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_k6h9i77m7pz7-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_6-1.start {
+        counter-reset: lst-ctn-kix_list_6-1 0;
+      }
+      .lst-kix_k6h9i77m7pz7-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_8dk1wnpc6r4-4 > li {
+        counter-increment: lst-ctn-kix_8dk1wnpc6r4-4;
+      }
+      ul.lst-kix_18uiv6s2ma8s-8 {
+        list-style-type: none;
+      }
+      .lst-kix_list_4-8 > li {
+        counter-increment: lst-ctn-kix_list_4-8;
+      }
+      .lst-kix_list_1-7 > li:before {
+        content: "(" counter(lst-ctn-kix_list_1-7, lower-latin) ") ";
+      }
+      .lst-kix_list_1-5 > li:before {
+        content: "(" counter(lst-ctn-kix_list_1-5, lower-latin) ") ";
+      }
+      .lst-kix_list_5-6 > li {
+        counter-increment: lst-ctn-kix_list_5-6;
+      }
+      .lst-kix_hrjx4g46ence-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_7nvigrru0za7-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_6fsdo8k08r38-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_u5xm10739dlx-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_u5xm10739dlx-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_list_2-1 > li:before {
+        content: "(" counter(lst-ctn-kix_list_2-1, lower-latin) ") ";
+      }
+      ul.lst-kix_18uiv6s2ma8s-5 {
+        list-style-type: none;
+      }
+      .lst-kix_list_2-3 > li:before {
+        content: "" counter(lst-ctn-kix_list_2-3, decimal) ") ";
+      }
+      ul.lst-kix_18uiv6s2ma8s-4 {
+        list-style-type: none;
+      }
+      .lst-kix_6fsdo8k08r38-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_18uiv6s2ma8s-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_74jv55lx6o4a-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_18uiv6s2ma8s-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_74jv55lx6o4a-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_18uiv6s2ma8s-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_74jv55lx6o4a-3 {
+        list-style-type: none;
+      }
+      .lst-kix_7nvigrru0za7-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_18uiv6s2ma8s-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_74jv55lx6o4a-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_18uiv6s2ma8s-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_74jv55lx6o4a-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_18uiv6s2ma8s-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_74jv55lx6o4a-4 {
+        list-style-type: none;
+      }
+      .lst-kix_7gcceflsf6k0-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_n81gzgxe38yj-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_tf0geodn37sd-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_tf0geodn37sd-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_7gcceflsf6k0-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_3-2 > li:before {
+        content: "" counter(lst-ctn-kix_list_3-0, decimal) "."
+          counter(lst-ctn-kix_list_3-1, decimal) "."
+          counter(lst-ctn-kix_list_3-2, decimal) ". ";
+      }
+      .lst-kix_e5mhrzfnma4q-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_1-8.start {
+        counter-reset: lst-ctn-kix_list_1-8 0;
+      }
+      .lst-kix_list_6-0 > li {
+        counter-increment: lst-ctn-kix_list_6-0;
+      }
+      .lst-kix_list_3-5 > li:before {
+        content: "" counter(lst-ctn-kix_list_3-0, decimal) "."
+          counter(lst-ctn-kix_list_3-1, decimal) "."
+          counter(lst-ctn-kix_list_3-2, decimal) "."
+          counter(lst-ctn-kix_list_3-3, decimal) "."
+          counter(lst-ctn-kix_list_3-4, decimal) "."
+          counter(lst-ctn-kix_list_3-5, decimal) ". ";
+      }
+      .lst-kix_e5mhrzfnma4q-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_z0lw2b2aattg-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_zhlek0m4ntir-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_nszccrumx3wm-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_ew66vvnubm3e-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ew66vvnubm3e-2 {
+        list-style-type: none;
+      }
+      .lst-kix_5bxzw67pmq0j-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_ew66vvnubm3e-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ew66vvnubm3e-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ew66vvnubm3e-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ew66vvnubm3e-3 {
+        list-style-type: none;
+      }
+      .lst-kix_zhlek0m4ntir-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_afzuvuipsb6i-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_ew66vvnubm3e-4 {
+        list-style-type: none;
+      }
+      .lst-kix_z0lw2b2aattg-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_ew66vvnubm3e-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ew66vvnubm3e-8 {
+        list-style-type: none;
+      }
+      .lst-kix_nszccrumx3wm-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_afzuvuipsb6i-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_5bxzw67pmq0j-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_5bxzw67pmq0j-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_eqlaut7noayk-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_e5mhrzfnma4q-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_n81gzgxe38yj-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_4-2.start {
+        counter-reset: lst-ctn-kix_list_4-2 1;
+      }
+      .lst-kix_z0lw2b2aattg-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_xwvuqm5td0w4-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_88zd2c7m8zo2-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_88zd2c7m8zo2-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_4-4 > li {
+        counter-increment: lst-ctn-kix_list_4-4;
+      }
+      .lst-kix_5ridsspeuiks-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_6-4.start {
+        counter-reset: lst-ctn-kix_list_6-4 0;
+      }
+      ul.lst-kix_7gcceflsf6k0-0 {
+        list-style-type: none;
+      }
+      .lst-kix_5ridsspeuiks-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_7gcceflsf6k0-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7gcceflsf6k0-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7gcceflsf6k0-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7gcceflsf6k0-8 {
+        list-style-type: none;
+      }
+      .lst-kix_88zd2c7m8zo2-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_4-1.start {
+        counter-reset: lst-ctn-kix_list_4-1 0;
+      }
+      ul.lst-kix_7gcceflsf6k0-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7gcceflsf6k0-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7gcceflsf6k0-6 {
+        list-style-type: none;
+      }
+      .lst-kix_u42wn2pu9hhe-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_7gcceflsf6k0-7 {
+        list-style-type: none;
+      }
+      .lst-kix_xwvuqm5td0w4-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_5k4kxq3iqk93-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_afzuvuipsb6i-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_jpvy5hdtq2p3-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_u42wn2pu9hhe-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_jpvy5hdtq2p3-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_3-3 > li {
+        counter-increment: lst-ctn-kix_list_3-3;
+      }
+      .lst-kix_5k4kxq3iqk93-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_6-3.start {
+        counter-reset: lst-ctn-kix_list_6-3 0;
+      }
+      .lst-kix_5k4kxq3iqk93-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_6852xf81qh5h-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_1roqjrv0u415-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_u42wn2pu9hhe-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_fvrr9fv4o79b-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_1roqjrv0u415-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_6852xf81qh5h-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_list_2-6 > li:before {
+        content: "" counter(lst-ctn-kix_list_2-6, decimal) ". ";
+      }
+      .lst-kix_n2t739nhbi13-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_5uyckpqard-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_fvrr9fv4o79b-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_list_6-7 > li {
+        counter-increment: lst-ctn-kix_list_6-7;
+      }
+      .lst-kix_d44mr7wbbmz9-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_6zv4pkv0v950-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_list_1-7 > li {
+        counter-increment: lst-ctn-kix_list_1-7;
+      }
+      .lst-kix_1qzjyx1qg1iy-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_t9ho1a2xas7j-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_n2t739nhbi13-0 {
+        list-style-type: none;
+      }
+      .lst-kix_ew66vvnubm3e-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_vhc5oluvxxf3-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_6-8.start {
+        counter-reset: lst-ctn-kix_list_6-8 0;
+      }
+      ol.lst-kix_list_1-7.start {
+        counter-reset: lst-ctn-kix_list_1-7 0;
+      }
+      ul.lst-kix_n2t739nhbi13-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_q4ylmkr5c9qa-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n2t739nhbi13-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_q4ylmkr5c9qa-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n2t739nhbi13-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_q4ylmkr5c9qa-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_di21lnsh0r0l-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_6-5.start {
+        counter-reset: lst-ctn-kix_list_6-5 0;
+      }
+      ul.lst-kix_n2t739nhbi13-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_q4ylmkr5c9qa-2 {
+        list-style-type: none;
+      }
+      .lst-kix_list_4-6 > li:before {
+        content: "" counter(lst-ctn-kix_list_4-0, decimal) "."
+          counter(lst-ctn-kix_list_4-1, decimal) "."
+          counter(lst-ctn-kix_list_4-2, decimal) "."
+          counter(lst-ctn-kix_list_4-3, decimal) "."
+          counter(lst-ctn-kix_list_4-4, decimal) "."
+          counter(lst-ctn-kix_list_4-5, decimal) "."
+          counter(lst-ctn-kix_list_4-6, decimal) ". ";
+      }
+      ul.lst-kix_n2t739nhbi13-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n2t739nhbi13-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n2t739nhbi13-1 {
+        list-style-type: none;
+      }
+      .lst-kix_8dk1wnpc6r4-8 > li {
+        counter-increment: lst-ctn-kix_8dk1wnpc6r4-8;
+      }
+      ul.lst-kix_n2t739nhbi13-2 {
+        list-style-type: none;
+      }
+      .lst-kix_74jv55lx6o4a-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_d44mr7wbbmz9-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_1qzjyx1qg1iy-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_18uiv6s2ma8s-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_6fsdo8k08r38-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_ys3df5ypy70p-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_di21lnsh0r0l-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_6-7.start {
+        counter-reset: lst-ctn-kix_list_6-7 0;
+      }
+      ul.lst-kix_q4ylmkr5c9qa-8 {
+        list-style-type: none;
+      }
+      .lst-kix_tn1l1rlq5s7-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_7nvigrru0za7-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_q4ylmkr5c9qa-5 {
+        list-style-type: none;
+      }
+      .lst-kix_k6h9i77m7pz7-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_q4ylmkr5c9qa-4 {
+        list-style-type: none;
+      }
+      .lst-kix_eqlaut7noayk-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_q4ylmkr5c9qa-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_q4ylmkr5c9qa-6 {
+        list-style-type: none;
+      }
+      .lst-kix_18uiv6s2ma8s-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_1-2 > li:before {
+        content: "" counter(lst-ctn-kix_list_1-2, decimal) ". ";
+      }
+      .lst-kix_mcion8kv1fq2-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_zc802926avdh-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_lv1czupk32gw-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_lv1czupk32gw-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_lv1czupk32gw-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_lv1czupk32gw-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_lv1czupk32gw-1 {
+        list-style-type: none;
+      }
+      .lst-kix_list_1-0 > li {
+        counter-increment: lst-ctn-kix_list_1-0;
+      }
+      ul.lst-kix_lv1czupk32gw-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_lv1czupk32gw-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_lv1czupk32gw-2 {
+        list-style-type: none;
+      }
+      .lst-kix_q4ylmkr5c9qa-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_u5xm10739dlx-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_lv1czupk32gw-8 {
+        list-style-type: none;
+      }
+      li.li-bullet-0:before {
+        margin-left: -18pt;
+        white-space: nowrap;
+        display: inline-block;
+        min-width: 18pt;
+      }
+      .lst-kix_u5xm10739dlx-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_8dk1wnpc6r4-1 > li {
+        counter-increment: lst-ctn-kix_8dk1wnpc6r4-1;
+      }
+      .lst-kix_mcion8kv1fq2-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_z4hxpql0fcdo-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_zc802926avdh-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_xwvuqm5td0w4-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_xwvuqm5td0w4-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_xwvuqm5td0w4-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_xwvuqm5td0w4-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_xwvuqm5td0w4-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_xwvuqm5td0w4-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_xwvuqm5td0w4-0 {
+        list-style-type: none;
+      }
+      .lst-kix_list_6-1 > li {
+        counter-increment: lst-ctn-kix_list_6-1;
+      }
+      ul.lst-kix_xwvuqm5td0w4-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_xwvuqm5td0w4-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8dk1wnpc6r4-5.start {
+        counter-reset: lst-ctn-kix_8dk1wnpc6r4-5 0;
+      }
+      ol.lst-kix_8dk1wnpc6r4-0.start {
+        counter-reset: lst-ctn-kix_8dk1wnpc6r4-0 0;
+      }
+      ol.lst-kix_list_3-7.start {
+        counter-reset: lst-ctn-kix_list_3-7 0;
+      }
+      .lst-kix_list_3-2 > li {
+        counter-increment: lst-ctn-kix_list_3-2;
+      }
+      .lst-kix_list_5-0 > li:before {
+        content: "(" counter(lst-ctn-kix_list_5-0, decimal) ") ";
+      }
+      ol.lst-kix_list_6-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_6-1 {
+        list-style-type: none;
+      }
+      .lst-kix_list_5-4 > li {
+        counter-increment: lst-ctn-kix_list_5-4;
+      }
+      ul.lst-kix_e5mhrzfnma4q-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_e5mhrzfnma4q-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_e5mhrzfnma4q-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_e5mhrzfnma4q-8 {
+        list-style-type: none;
+      }
+      .lst-kix_list_5-3 > li:before {
+        content: "" counter(lst-ctn-kix_list_5-3, decimal) ". ";
+      }
+      ul.lst-kix_di21lnsh0r0l-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_di21lnsh0r0l-3 {
+        list-style-type: none;
+      }
+      .lst-kix_list_5-2 > li:before {
+        content: "" counter(lst-ctn-kix_list_5-2, lower-roman) ". ";
+      }
+      ul.lst-kix_di21lnsh0r0l-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_di21lnsh0r0l-1 {
+        list-style-type: none;
+      }
+      .lst-kix_list_5-1 > li:before {
+        content: "" counter(lst-ctn-kix_list_5-1, lower-latin) ". ";
+      }
+      ul.lst-kix_di21lnsh0r0l-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_di21lnsh0r0l-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_di21lnsh0r0l-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_di21lnsh0r0l-5 {
+        list-style-type: none;
+      }
+      .lst-kix_list_5-7 > li:before {
+        content: "" counter(lst-ctn-kix_list_5-7, lower-latin) ". ";
+      }
+      .lst-kix_8dk1wnpc6r4-2 > li {
+        counter-increment: lst-ctn-kix_8dk1wnpc6r4-2;
+      }
+      .lst-kix_list_5-6 > li:before {
+        content: "" counter(lst-ctn-kix_list_5-6, decimal) ". ";
+      }
+      .lst-kix_list_5-8 > li:before {
+        content: "" counter(lst-ctn-kix_list_5-8, lower-roman) ". ";
+      }
+      ol.lst-kix_list_6-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_e5mhrzfnma4q-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_6-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_e5mhrzfnma4q-2 {
+        list-style-type: none;
+      }
+      .lst-kix_list_5-4 > li:before {
+        content: "" counter(lst-ctn-kix_list_5-4, lower-latin) ". ";
+      }
+      ol.lst-kix_list_6-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_e5mhrzfnma4q-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_e5mhrzfnma4q-4 {
+        list-style-type: none;
+      }
+      .lst-kix_list_5-5 > li:before {
+        content: "" counter(lst-ctn-kix_list_5-5, lower-roman) ". ";
+      }
+      ol.lst-kix_list_6-2 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_6-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_6-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_6-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_e5mhrzfnma4q-0 {
+        list-style-type: none;
+      }
+      .lst-kix_list_6-1 > li:before {
+        content: "" counter(lst-ctn-kix_list_6-0, lower-roman) "."
+          counter(lst-ctn-kix_list_6-1, decimal) ". ";
+      }
+      .lst-kix_list_6-3 > li:before {
+        content: "" counter(lst-ctn-kix_list_6-0, lower-roman) "."
+          counter(lst-ctn-kix_list_6-1, decimal) "."
+          counter(lst-ctn-kix_list_6-2, decimal) "."
+          counter(lst-ctn-kix_list_6-3, decimal) ". ";
+      }
+      .lst-kix_list_6-8 > li {
+        counter-increment: lst-ctn-kix_list_6-8;
+      }
+      .lst-kix_list_6-0 > li:before {
+        content: "" counter(lst-ctn-kix_list_6-0, lower-roman) ". ";
+      }
+      .lst-kix_list_6-4 > li:before {
+        content: "" counter(lst-ctn-kix_list_6-0, lower-roman) "."
+          counter(lst-ctn-kix_list_6-1, decimal) "."
+          counter(lst-ctn-kix_list_6-2, decimal) "."
+          counter(lst-ctn-kix_list_6-3, decimal) "."
+          counter(lst-ctn-kix_list_6-4, decimal) ". ";
+      }
+      .lst-kix_list_6-2 > li:before {
+        content: "" counter(lst-ctn-kix_list_6-0, lower-roman) "."
+          counter(lst-ctn-kix_list_6-1, decimal) "."
+          counter(lst-ctn-kix_list_6-2, decimal) ". ";
+      }
+      ul.lst-kix_hrjx4g46ence-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_hrjx4g46ence-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_hrjx4g46ence-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_hrjx4g46ence-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_hrjx4g46ence-1 {
+        list-style-type: none;
+      }
+      .lst-kix_list_2-5 > li {
+        counter-increment: lst-ctn-kix_list_2-5;
+      }
+      ol.lst-kix_list_3-2.start {
+        counter-reset: lst-ctn-kix_list_3-2 0;
+      }
+      ul.lst-kix_hrjx4g46ence-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_hrjx4g46ence-3 {
+        list-style-type: none;
+      }
+      .lst-kix_list_6-8 > li:before {
+        content: "" counter(lst-ctn-kix_list_6-0, lower-roman) "."
+          counter(lst-ctn-kix_list_6-1, decimal) "."
+          counter(lst-ctn-kix_list_6-2, decimal) "."
+          counter(lst-ctn-kix_list_6-3, decimal) "."
+          counter(lst-ctn-kix_list_6-4, decimal) "."
+          counter(lst-ctn-kix_list_6-5, decimal) "."
+          counter(lst-ctn-kix_list_6-6, decimal) "."
+          counter(lst-ctn-kix_list_6-7, decimal) "."
+          counter(lst-ctn-kix_list_6-8, decimal) ". ";
+      }
+      ul.lst-kix_hrjx4g46ence-4 {
+        list-style-type: none;
+      }
+      .lst-kix_list_6-5 > li:before {
+        content: "" counter(lst-ctn-kix_list_6-0, lower-roman) "."
+          counter(lst-ctn-kix_list_6-1, decimal) "."
+          counter(lst-ctn-kix_list_6-2, decimal) "."
+          counter(lst-ctn-kix_list_6-3, decimal) "."
+          counter(lst-ctn-kix_list_6-4, decimal) "."
+          counter(lst-ctn-kix_list_6-5, decimal) ". ";
+      }
+      .lst-kix_list_6-7 > li:before {
+        content: "" counter(lst-ctn-kix_list_6-0, lower-roman) "."
+          counter(lst-ctn-kix_list_6-1, decimal) "."
+          counter(lst-ctn-kix_list_6-2, decimal) "."
+          counter(lst-ctn-kix_list_6-3, decimal) "."
+          counter(lst-ctn-kix_list_6-4, decimal) "."
+          counter(lst-ctn-kix_list_6-5, decimal) "."
+          counter(lst-ctn-kix_list_6-6, decimal) "."
+          counter(lst-ctn-kix_list_6-7, decimal) ". ";
+      }
+      ul.lst-kix_hrjx4g46ence-0 {
+        list-style-type: none;
+      }
+      .lst-kix_list_6-6 > li:before {
+        content: "" counter(lst-ctn-kix_list_6-0, lower-roman) "."
+          counter(lst-ctn-kix_list_6-1, decimal) "."
+          counter(lst-ctn-kix_list_6-2, decimal) "."
+          counter(lst-ctn-kix_list_6-3, decimal) "."
+          counter(lst-ctn-kix_list_6-4, decimal) "."
+          counter(lst-ctn-kix_list_6-5, decimal) "."
+          counter(lst-ctn-kix_list_6-6, decimal) ". ";
+      }
+      .lst-kix_d44mr7wbbmz9-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_d44mr7wbbmz9-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_d44mr7wbbmz9-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_tn1l1rlq5s7-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tn1l1rlq5s7-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_6-2.start {
+        counter-reset: lst-ctn-kix_list_6-2 0;
+      }
+      ul.lst-kix_tn1l1rlq5s7-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tn1l1rlq5s7-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tn1l1rlq5s7-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tn1l1rlq5s7-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tn1l1rlq5s7-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tn1l1rlq5s7-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_tn1l1rlq5s7-7 {
+        list-style-type: none;
+      }
+      .lst-kix_d44mr7wbbmz9-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_list_4-7 > li {
+        counter-increment: lst-ctn-kix_list_4-7;
+      }
+      .lst-kix_vhc5oluvxxf3-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_2-5.start {
+        counter-reset: lst-ctn-kix_list_2-5 0;
+      }
+      .lst-kix_vhc5oluvxxf3-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_list_4-1 > li:before {
+        content: "" counter(lst-ctn-kix_list_4-0, decimal) "."
+          counter(lst-ctn-kix_list_4-1, decimal) ". ";
+      }
+      .lst-kix_vhc5oluvxxf3-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_vhc5oluvxxf3-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_4-3 > li:before {
+        content: "" counter(lst-ctn-kix_list_4-0, decimal) "."
+          counter(lst-ctn-kix_list_4-1, decimal) "."
+          counter(lst-ctn-kix_list_4-2, decimal) "."
+          counter(lst-ctn-kix_list_4-3, decimal) ". ";
+      }
+      .lst-kix_list_4-5 > li:before {
+        content: "" counter(lst-ctn-kix_list_4-0, decimal) "."
+          counter(lst-ctn-kix_list_4-1, decimal) "."
+          counter(lst-ctn-kix_list_4-2, decimal) "."
+          counter(lst-ctn-kix_list_4-3, decimal) "."
+          counter(lst-ctn-kix_list_4-4, decimal) "."
+          counter(lst-ctn-kix_list_4-5, decimal) ". ";
+      }
+      .lst-kix_di21lnsh0r0l-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_di21lnsh0r0l-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_1-8 > li {
+        counter-increment: lst-ctn-kix_list_1-8;
+      }
+      ol.lst-kix_list_1-4.start {
+        counter-reset: lst-ctn-kix_list_1-4 0;
+      }
+      .lst-kix_5ridsspeuiks-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_vhc5oluvxxf3-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_6852xf81qh5h-0 {
+        list-style-type: none;
+      }
+      .lst-kix_18uiv6s2ma8s-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ol.lst-kix_list_4-4.start {
+        counter-reset: lst-ctn-kix_list_4-4 0;
+      }
+      .lst-kix_18uiv6s2ma8s-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_18uiv6s2ma8s-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_5ridsspeuiks-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_di21lnsh0r0l-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_q4ylmkr5c9qa-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_1roqjrv0u415-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1roqjrv0u415-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1roqjrv0u415-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1roqjrv0u415-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5bxzw67pmq0j-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1roqjrv0u415-6 {
+        list-style-type: none;
+      }
+      .lst-kix_18uiv6s2ma8s-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_5bxzw67pmq0j-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1roqjrv0u415-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5bxzw67pmq0j-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1roqjrv0u415-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5bxzw67pmq0j-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1roqjrv0u415-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5bxzw67pmq0j-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6852xf81qh5h-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5bxzw67pmq0j-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6852xf81qh5h-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5bxzw67pmq0j-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6852xf81qh5h-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5bxzw67pmq0j-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6852xf81qh5h-5 {
+        list-style-type: none;
+      }
+      .lst-kix_di21lnsh0r0l-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_zhlek0m4ntir-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_6852xf81qh5h-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6852xf81qh5h-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1roqjrv0u415-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6852xf81qh5h-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5bxzw67pmq0j-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6852xf81qh5h-1 {
+        list-style-type: none;
+      }
+      .lst-kix_q4ylmkr5c9qa-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_q4ylmkr5c9qa-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_6fsdo8k08r38-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n81gzgxe38yj-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6fsdo8k08r38-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n81gzgxe38yj-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6fsdo8k08r38-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n81gzgxe38yj-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n81gzgxe38yj-2 {
+        list-style-type: none;
+      }
+      .lst-kix_q4ylmkr5c9qa-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_n81gzgxe38yj-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n81gzgxe38yj-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n81gzgxe38yj-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n81gzgxe38yj-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u5xm10739dlx-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u5xm10739dlx-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6fsdo8k08r38-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6fsdo8k08r38-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u5xm10739dlx-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6fsdo8k08r38-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u5xm10739dlx-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6fsdo8k08r38-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u5xm10739dlx-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_n81gzgxe38yj-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6fsdo8k08r38-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u5xm10739dlx-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_6fsdo8k08r38-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u5xm10739dlx-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_u5xm10739dlx-1 {
+        list-style-type: none;
+      }
+      .lst-kix_q4ylmkr5c9qa-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_u5xm10739dlx-0 {
+        list-style-type: none;
+      }
+      .lst-kix_list_1-1 > li {
+        counter-increment: lst-ctn-kix_list_1-1;
+      }
+      ol.lst-kix_list_2-6.start {
+        counter-reset: lst-ctn-kix_list_2-6 0;
+      }
+      .lst-kix_list_3-0 > li:before {
+        content: "" counter(lst-ctn-kix_list_3-0, decimal) ". ";
+      }
+      .lst-kix_list_4-0 > li {
+        counter-increment: lst-ctn-kix_list_4-0;
+      }
+      .lst-kix_list_3-4 > li:before {
+        content: "" counter(lst-ctn-kix_list_3-0, decimal) "."
+          counter(lst-ctn-kix_list_3-1, decimal) "."
+          counter(lst-ctn-kix_list_3-2, decimal) "."
+          counter(lst-ctn-kix_list_3-3, decimal) "."
+          counter(lst-ctn-kix_list_3-4, decimal) ". ";
+      }
+      .lst-kix_list_3-3 > li:before {
+        content: "" counter(lst-ctn-kix_list_3-0, decimal) "."
+          counter(lst-ctn-kix_list_3-1, decimal) "."
+          counter(lst-ctn-kix_list_3-2, decimal) "."
+          counter(lst-ctn-kix_list_3-3, decimal) ". ";
+      }
+      .lst-kix_list_3-8 > li:before {
+        content: "" counter(lst-ctn-kix_list_3-0, decimal) "."
+          counter(lst-ctn-kix_list_3-1, decimal) "."
+          counter(lst-ctn-kix_list_3-2, decimal) "."
+          counter(lst-ctn-kix_list_3-3, decimal) "."
+          counter(lst-ctn-kix_list_3-4, decimal) "."
+          counter(lst-ctn-kix_list_3-5, decimal) "."
+          counter(lst-ctn-kix_list_3-6, decimal) "."
+          counter(lst-ctn-kix_list_3-7, decimal) "."
+          counter(lst-ctn-kix_list_3-8, decimal) ". ";
+      }
+      .lst-kix_zhlek0m4ntir-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_list_3-7 > li:before {
+        content: "" counter(lst-ctn-kix_list_3-0, decimal) "."
+          counter(lst-ctn-kix_list_3-1, decimal) "."
+          counter(lst-ctn-kix_list_3-2, decimal) "."
+          counter(lst-ctn-kix_list_3-3, decimal) "."
+          counter(lst-ctn-kix_list_3-4, decimal) "."
+          counter(lst-ctn-kix_list_3-5, decimal) "."
+          counter(lst-ctn-kix_list_3-6, decimal) "."
+          counter(lst-ctn-kix_list_3-7, decimal) ". ";
+      }
+      .lst-kix_zhlek0m4ntir-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_2-2 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_2-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_2-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_2-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_zhlek0m4ntir-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_zhlek0m4ntir-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_2-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_2-1 {
+        list-style-type: none;
+      }
+      .lst-kix_list_4-8 > li:before {
+        content: "" counter(lst-ctn-kix_list_4-0, decimal) "."
+          counter(lst-ctn-kix_list_4-1, decimal) "."
+          counter(lst-ctn-kix_list_4-2, decimal) "."
+          counter(lst-ctn-kix_list_4-3, decimal) "."
+          counter(lst-ctn-kix_list_4-4, decimal) "."
+          counter(lst-ctn-kix_list_4-5, decimal) "."
+          counter(lst-ctn-kix_list_4-6, decimal) "."
+          counter(lst-ctn-kix_list_4-7, decimal) "."
+          counter(lst-ctn-kix_list_4-8, decimal) ". ";
+      }
+      ul.lst-kix_zhlek0m4ntir-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_zhlek0m4ntir-3 {
+        list-style-type: none;
+      }
+      .lst-kix_list_4-7 > li:before {
+        content: "" counter(lst-ctn-kix_list_4-0, decimal) "."
+          counter(lst-ctn-kix_list_4-1, decimal) "."
+          counter(lst-ctn-kix_list_4-2, decimal) "."
+          counter(lst-ctn-kix_list_4-3, decimal) "."
+          counter(lst-ctn-kix_list_4-4, decimal) "."
+          counter(lst-ctn-kix_list_4-5, decimal) "."
+          counter(lst-ctn-kix_list_4-6, decimal) "."
+          counter(lst-ctn-kix_list_4-7, decimal) ". ";
+      }
+      ul.lst-kix_zhlek0m4ntir-6 {
+        list-style-type: none;
+      }
+      .lst-kix_6852xf81qh5h-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_zhlek0m4ntir-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_zhlek0m4ntir-0 {
+        list-style-type: none;
+      }
+      .lst-kix_5ridsspeuiks-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_zhlek0m4ntir-2 {
+        list-style-type: none;
+      }
+      .lst-kix_5ridsspeuiks-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_zhlek0m4ntir-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_4-8.start {
+        counter-reset: lst-ctn-kix_list_4-8 0;
+      }
+      ol.lst-kix_list_3-3.start {
+        counter-reset: lst-ctn-kix_list_3-3 0;
+      }
+      ol.lst-kix_list_2-6 {
+        list-style-type: none;
+      }
+      .lst-kix_jpvy5hdtq2p3-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_2-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_2-8 {
+        list-style-type: none;
+      }
+      .lst-kix_jpvy5hdtq2p3-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_5k4kxq3iqk93-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_5k4kxq3iqk93-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_jpvy5hdtq2p3-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_6852xf81qh5h-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_jpvy5hdtq2p3-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_6852xf81qh5h-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_6852xf81qh5h-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_5k4kxq3iqk93-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_5k4kxq3iqk93-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_6852xf81qh5h-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_jpvy5hdtq2p3-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_d44mr7wbbmz9-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_n2t739nhbi13-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_2-4 > li:before {
+        content: "" counter(lst-ctn-kix_list_2-4, lower-latin) ") ";
+      }
+      .lst-kix_list_2-8 > li:before {
+        content: "" counter(lst-ctn-kix_list_2-8, lower-roman) ". ";
+      }
+      .lst-kix_6zv4pkv0v950-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_mcion8kv1fq2-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_mcion8kv1fq2-0 {
+        list-style-type: none;
+      }
+      .lst-kix_n2t739nhbi13-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_n2t739nhbi13-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_6zv4pkv0v950-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_mcion8kv1fq2-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_mcion8kv1fq2-4 {
+        list-style-type: none;
+      }
+      .lst-kix_d44mr7wbbmz9-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_mcion8kv1fq2-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_mcion8kv1fq2-2 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_3-8.start {
+        counter-reset: lst-ctn-kix_list_3-8 0;
+      }
+      ul.lst-kix_mcion8kv1fq2-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_mcion8kv1fq2-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_mcion8kv1fq2-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_zc802926avdh-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_zc802926avdh-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_zc802926avdh-6 {
+        list-style-type: none;
+      }
+      .lst-kix_vhc5oluvxxf3-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_zc802926avdh-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_zc802926avdh-4 {
+        list-style-type: none;
+      }
+      .lst-kix_list_4-0 > li:before {
+        content: "" counter(lst-ctn-kix_list_4-0, decimal) ". ";
+      }
+      ul.lst-kix_zc802926avdh-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_zc802926avdh-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_zc802926avdh-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_zc802926avdh-0 {
+        list-style-type: none;
+      }
+      .lst-kix_list_4-4 > li:before {
+        content: "" counter(lst-ctn-kix_list_4-0, decimal) "."
+          counter(lst-ctn-kix_list_4-1, decimal) "."
+          counter(lst-ctn-kix_list_4-2, decimal) "."
+          counter(lst-ctn-kix_list_4-3, decimal) "."
+          counter(lst-ctn-kix_list_4-4, decimal) ". ";
+      }
+      ul.lst-kix_fnj7klr0wrov-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_fnj7klr0wrov-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_fnj7klr0wrov-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_fnj7klr0wrov-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_fnj7klr0wrov-8 {
+        list-style-type: none;
+      }
+      .lst-kix_vhc5oluvxxf3-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_fnj7klr0wrov-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8dk1wnpc6r4-6.start {
+        counter-reset: lst-ctn-kix_8dk1wnpc6r4-6 0;
+      }
+      ul.lst-kix_fnj7klr0wrov-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_fnj7klr0wrov-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_fnj7klr0wrov-1 {
+        list-style-type: none;
+      }
+      .lst-kix_5ridsspeuiks-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_di21lnsh0r0l-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_4-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_4-1 {
+        list-style-type: none;
+      }
+      .lst-kix_mcion8kv1fq2-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_4-2 {
+        list-style-type: none;
+      }
+      .lst-kix_18uiv6s2ma8s-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_4-3 {
+        list-style-type: none;
+      }
+      .lst-kix_list_2-4 > li {
+        counter-increment: lst-ctn-kix_list_2-4;
+      }
+      ol.lst-kix_list_3-6.start {
+        counter-reset: lst-ctn-kix_list_3-6 0;
+      }
+      .lst-kix_mcion8kv1fq2-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_18uiv6s2ma8s-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_di21lnsh0r0l-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_6fsdo8k08r38-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_eqlaut7noayk-0 {
+        list-style-type: none;
+      }
+      .lst-kix_k6h9i77m7pz7-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_eqlaut7noayk-1 {
+        list-style-type: none;
+      }
+      .lst-kix_list_5-3 > li {
+        counter-increment: lst-ctn-kix_list_5-3;
+      }
+      ul.lst-kix_eqlaut7noayk-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_eqlaut7noayk-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_eqlaut7noayk-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_eqlaut7noayk-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_4-8 {
+        list-style-type: none;
+      }
+      .lst-kix_k6h9i77m7pz7-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_1-0 > li:before {
+        content: "" counter(lst-ctn-kix_list_1-0, lower-roman) ". ";
+      }
+      .lst-kix_zhlek0m4ntir-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_7nvigrru0za7-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_4-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_4-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_2-0.start {
+        counter-reset: lst-ctn-kix_list_2-0 0;
+      }
+      ol.lst-kix_list_4-6 {
+        list-style-type: none;
+      }
+      .lst-kix_di21lnsh0r0l-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_4-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_m6fvupggs9zx-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_88zd2c7m8zo2-8 {
+        list-style-type: none;
+      }
+      .lst-kix_list_1-4 > li:before {
+        content: "(" counter(lst-ctn-kix_list_1-4, decimal) ") ";
+      }
+      ul.lst-kix_m6fvupggs9zx-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_88zd2c7m8zo2-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_m6fvupggs9zx-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_m6fvupggs9zx-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_m6fvupggs9zx-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_88zd2c7m8zo2-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_m6fvupggs9zx-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_88zd2c7m8zo2-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_m6fvupggs9zx-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_88zd2c7m8zo2-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_m6fvupggs9zx-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_88zd2c7m8zo2-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_eqlaut7noayk-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5grxh0nlok2c-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_88zd2c7m8zo2-0 {
+        list-style-type: none;
+      }
+      .lst-kix_list_1-6 > li {
+        counter-increment: lst-ctn-kix_list_1-6;
+      }
+      ul.lst-kix_5grxh0nlok2c-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_eqlaut7noayk-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5grxh0nlok2c-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_88zd2c7m8zo2-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_eqlaut7noayk-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5grxh0nlok2c-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_88zd2c7m8zo2-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8dk1wnpc6r4-4.start {
+        counter-reset: lst-ctn-kix_8dk1wnpc6r4-4 0;
+      }
+      ul.lst-kix_m6fvupggs9zx-0 {
+        list-style-type: none;
+      }
+      .lst-kix_q4ylmkr5c9qa-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_5grxh0nlok2c-1 {
+        list-style-type: none;
+      }
+      .lst-kix_u5xm10739dlx-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_5grxh0nlok2c-0 {
+        list-style-type: none;
+      }
+      .lst-kix_7nvigrru0za7-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_5grxh0nlok2c-7 {
+        list-style-type: none;
+      }
+      .lst-kix_list_2-0 > li:before {
+        content: "(" counter(lst-ctn-kix_list_2-0, upper-latin) ") ";
+      }
+      ol.lst-kix_list_2-1.start {
+        counter-reset: lst-ctn-kix_list_2-1 0;
+      }
+      ul.lst-kix_5grxh0nlok2c-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_5grxh0nlok2c-8 {
+        list-style-type: none;
+      }
+      .lst-kix_list_4-5 > li {
+        counter-increment: lst-ctn-kix_list_4-5;
+      }
+      .lst-kix_6fsdo8k08r38-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_list_1-8 > li:before {
+        content: "(" counter(lst-ctn-kix_list_1-8, lower-roman) ") ";
+      }
+      .lst-kix_7nvigrru0za7-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_q4ylmkr5c9qa-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_u5xm10739dlx-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_fvrr9fv4o79b-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_fvrr9fv4o79b-6 {
+        list-style-type: none;
+      }
+      .lst-kix_ipq87akvuv4n-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_fvrr9fv4o79b-7 {
+        list-style-type: none;
+      }
+      .lst-kix_hrjx4g46ence-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_fvrr9fv4o79b-8 {
+        list-style-type: none;
+      }
+      .lst-kix_8dk1wnpc6r4-0 > li {
+        counter-increment: lst-ctn-kix_8dk1wnpc6r4-0;
+      }
+      .lst-kix_ipq87akvuv4n-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_ipq87akvuv4n-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_hrjx4g46ence-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_ipq87akvuv4n-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_hrjx4g46ence-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_3-1.start {
+        counter-reset: lst-ctn-kix_list_3-1 0;
+      }
+      .lst-kix_5grxh0nlok2c-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_5grxh0nlok2c-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_f9961645pj1n-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_f9961645pj1n-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_5grxh0nlok2c-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_fvrr9fv4o79b-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_fvrr9fv4o79b-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_fvrr9fv4o79b-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_fvrr9fv4o79b-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_fvrr9fv4o79b-4 {
+        list-style-type: none;
+      }
+      .lst-kix_8dk1wnpc6r4-0 > li:before {
+        content: "" counter(lst-ctn-kix_8dk1wnpc6r4-0, decimal) ". ";
+      }
+      .lst-kix_list_2-3 > li {
+        counter-increment: lst-ctn-kix_list_2-3;
+      }
+      .lst-kix_f9961645pj1n-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_lv1czupk32gw-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_gzdocpm58hz7-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_1-2 > li {
+        counter-increment: lst-ctn-kix_list_1-2;
+      }
+      .lst-kix_8dk1wnpc6r4-8 > li:before {
+        content: "" counter(lst-ctn-kix_8dk1wnpc6r4-8, lower-roman) ". ";
+      }
+      .lst-kix_gzdocpm58hz7-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_5grxh0nlok2c-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_8dk1wnpc6r4-6 > li:before {
+        content: "" counter(lst-ctn-kix_8dk1wnpc6r4-6, decimal) ". ";
+      }
+      .lst-kix_8dk1wnpc6r4-3 > li:before {
+        content: "" counter(lst-ctn-kix_8dk1wnpc6r4-3, decimal) ". ";
+      }
+      .lst-kix_5grxh0nlok2c-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_f9961645pj1n-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_8dk1wnpc6r4-5 > li:before {
+        content: "" counter(lst-ctn-kix_8dk1wnpc6r4-5, lower-roman) ". ";
+      }
+      .lst-kix_23dxydqlwhcr-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_gzdocpm58hz7-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_23dxydqlwhcr-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_74jv55lx6o4a-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_gzdocpm58hz7-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_khiuhskpdykq-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_lv1czupk32gw-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_khiuhskpdykq-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_23dxydqlwhcr-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_wwx8zpyq2pae-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_23dxydqlwhcr-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_23dxydqlwhcr-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_wwx8zpyq2pae-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_21mtbyoilxak-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_gzdocpm58hz7-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_lv1czupk32gw-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_74jv55lx6o4a-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_wwx8zpyq2pae-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_21mtbyoilxak-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_lv1czupk32gw-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_lv1czupk32gw-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_23dxydqlwhcr-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_23dxydqlwhcr-7 {
+        list-style-type: none;
+      }
+      .lst-kix_21mtbyoilxak-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_23dxydqlwhcr-8 {
+        list-style-type: none;
+      }
+      .lst-kix_74jv55lx6o4a-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_wwx8zpyq2pae-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_21mtbyoilxak-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_m6fvupggs9zx-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_m6fvupggs9zx-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_23dxydqlwhcr-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_23dxydqlwhcr-3 {
+        list-style-type: none;
+      }
+      .lst-kix_wwx8zpyq2pae-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_23dxydqlwhcr-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_23dxydqlwhcr-5 {
+        list-style-type: none;
+      }
+      .lst-kix_m6fvupggs9zx-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_23dxydqlwhcr-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_23dxydqlwhcr-1 {
+        list-style-type: none;
+      }
+      .lst-kix_khiuhskpdykq-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_khiuhskpdykq-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_m6fvupggs9zx-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ol.lst-kix_list_2-4.start {
+        counter-reset: lst-ctn-kix_list_2-4 0;
+      }
+      .lst-kix_khiuhskpdykq-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_1-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_1-4 {
+        list-style-type: none;
+      }
+      .lst-kix_list_2-7 > li:before {
+        content: "" counter(lst-ctn-kix_list_2-7, lower-latin) ". ";
+      }
+      .lst-kix_list_2-7 > li {
+        counter-increment: lst-ctn-kix_list_2-7;
+      }
+      ol.lst-kix_list_1-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_1-6 {
+        list-style-type: none;
+      }
+      .lst-kix_1roqjrv0u415-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_1-0 {
+        list-style-type: none;
+      }
+      .lst-kix_list_2-5 > li:before {
+        content: "" counter(lst-ctn-kix_list_2-5, lower-roman) ") ";
+      }
+      ol.lst-kix_list_1-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_1-2 {
+        list-style-type: none;
+      }
+      .lst-kix_n2t739nhbi13-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_n2t739nhbi13-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_6zv4pkv0v950-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_6zv4pkv0v950-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ol.lst-kix_list_1-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_1-8 {
+        list-style-type: none;
+      }
+      .lst-kix_t9ho1a2xas7j-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_2-6 > li {
+        counter-increment: lst-ctn-kix_list_2-6;
+      }
+      .lst-kix_74jv55lx6o4a-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_5-7.start {
+        counter-reset: lst-ctn-kix_list_5-7 0;
+      }
+      .lst-kix_74jv55lx6o4a-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_t9ho1a2xas7j-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_3-4 > li {
+        counter-increment: lst-ctn-kix_list_3-4;
+      }
+      .lst-kix_mcion8kv1fq2-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_k6h9i77m7pz7-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_6fsdo8k08r38-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_ys3df5ypy70p-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_k6h9i77m7pz7-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_7nvigrru0za7-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_ys3df5ypy70p-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_7nvigrru0za7-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_6fsdo8k08r38-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_mcion8kv1fq2-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_list_1-1 > li:before {
+        content: "" counter(lst-ctn-kix_list_1-1, upper-latin) ". ";
+      }
+      .lst-kix_list_1-3 > li:before {
+        content: "" counter(lst-ctn-kix_list_1-3, lower-latin) ") ";
+      }
+      ol.lst-kix_list_2-7.start {
+        counter-reset: lst-ctn-kix_list_2-7 0;
+      }
+      .lst-kix_u5xm10739dlx-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_k6h9i77m7pz7-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_hrjx4g46ence-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_6fsdo8k08r38-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_u5xm10739dlx-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_tf0geodn37sd-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_list_3-1 > li {
+        counter-increment: lst-ctn-kix_list_3-1;
+      }
+      .lst-kix_n81gzgxe38yj-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_e5mhrzfnma4q-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_list_3-1 > li:before {
+        content: "" counter(lst-ctn-kix_list_3-0, decimal) "."
+          counter(lst-ctn-kix_list_3-1, decimal) ". ";
+      }
+      .lst-kix_tf0geodn37sd-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_7gcceflsf6k0-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_tf0geodn37sd-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_z0lw2b2aattg-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_nszccrumx3wm-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_zhlek0m4ntir-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_afzuvuipsb6i-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_list_2-0 > li {
+        counter-increment: lst-ctn-kix_list_2-0;
+      }
+      .lst-kix_zhlek0m4ntir-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_ipq87akvuv4n-8 {
+        list-style-type: none;
+      }
+      .lst-kix_afzuvuipsb6i-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_5bxzw67pmq0j-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_ipq87akvuv4n-7 {
+        list-style-type: none;
+      }
+      .lst-kix_list_3-6 > li:before {
+        content: "" counter(lst-ctn-kix_list_3-0, decimal) "."
+          counter(lst-ctn-kix_list_3-1, decimal) "."
+          counter(lst-ctn-kix_list_3-2, decimal) "."
+          counter(lst-ctn-kix_list_3-3, decimal) "."
+          counter(lst-ctn-kix_list_3-4, decimal) "."
+          counter(lst-ctn-kix_list_3-5, decimal) "."
+          counter(lst-ctn-kix_list_3-6, decimal) ". ";
+      }
+      .lst-kix_nszccrumx3wm-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_ipq87akvuv4n-4 {
+        list-style-type: none;
+      }
+      .lst-kix_z0lw2b2aattg-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_ipq87akvuv4n-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ipq87akvuv4n-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ipq87akvuv4n-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_5-0.start {
+        counter-reset: lst-ctn-kix_list_5-0 0;
+      }
+      .lst-kix_n81gzgxe38yj-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_5bxzw67pmq0j-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_e5mhrzfnma4q-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_nszccrumx3wm-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_z0lw2b2aattg-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8dk1wnpc6r4-2 {
+        list-style-type: none;
+      }
+      .lst-kix_5ridsspeuiks-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ol.lst-kix_8dk1wnpc6r4-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z0lw2b2aattg-2 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8dk1wnpc6r4-0 {
+        list-style-type: none;
+      }
+      .lst-kix_xwvuqm5td0w4-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_z0lw2b2aattg-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8dk1wnpc6r4-6 {
+        list-style-type: none;
+      }
+      .lst-kix_8dk1wnpc6r4-3 > li {
+        counter-increment: lst-ctn-kix_8dk1wnpc6r4-3;
+      }
+      ol.lst-kix_8dk1wnpc6r4-5 {
+        list-style-type: none;
+      }
+      .lst-kix_88zd2c7m8zo2-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ol.lst-kix_8dk1wnpc6r4-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8dk1wnpc6r4-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z0lw2b2aattg-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z0lw2b2aattg-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z0lw2b2aattg-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z0lw2b2aattg-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z0lw2b2aattg-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z0lw2b2aattg-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ipq87akvuv4n-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_5-6.start {
+        counter-reset: lst-ctn-kix_list_5-6 0;
+      }
+      ul.lst-kix_ipq87akvuv4n-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ipq87akvuv4n-1 {
+        list-style-type: none;
+      }
+      .lst-kix_u42wn2pu9hhe-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_88zd2c7m8zo2-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_xwvuqm5td0w4-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_8dk1wnpc6r4-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8dk1wnpc6r4-7 {
+        list-style-type: none;
+      }
+      .lst-kix_jpvy5hdtq2p3-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_z4hxpql0fcdo-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z4hxpql0fcdo-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7nvigrru0za7-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z4hxpql0fcdo-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z4hxpql0fcdo-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z4hxpql0fcdo-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z4hxpql0fcdo-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z4hxpql0fcdo-2 {
+        list-style-type: none;
+      }
+      .lst-kix_5k4kxq3iqk93-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_7nvigrru0za7-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z4hxpql0fcdo-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7nvigrru0za7-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_z4hxpql0fcdo-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7nvigrru0za7-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7nvigrru0za7-8 {
+        list-style-type: none;
+      }
+      .lst-kix_6852xf81qh5h-1 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_7nvigrru0za7-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7nvigrru0za7-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7nvigrru0za7-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_7nvigrru0za7-4 {
+        list-style-type: none;
+      }
+      .lst-kix_5k4kxq3iqk93-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_1roqjrv0u415-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_fvrr9fv4o79b-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_jpvy5hdtq2p3-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ol.lst-kix_list_5-5.start {
+        counter-reset: lst-ctn-kix_list_5-5 0;
+      }
+      .lst-kix_u42wn2pu9hhe-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_6852xf81qh5h-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_7gcceflsf6k0-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_list_6-2 > li {
+        counter-increment: lst-ctn-kix_list_6-2;
+      }
+      ul.lst-kix_1qzjyx1qg1iy-8 {
+        list-style-type: none;
+      }
+      .lst-kix_d44mr7wbbmz9-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_6zv4pkv0v950-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_z4hxpql0fcdo-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_list_5-4.start {
+        counter-reset: lst-ctn-kix_list_5-4 0;
+      }
+      .lst-kix_1qzjyx1qg1iy-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_k6h9i77m7pz7-1 {
+        list-style-type: none;
+      }
+      .lst-kix_ew66vvnubm3e-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_k6h9i77m7pz7-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_k6h9i77m7pz7-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_list_5-1.start {
+        counter-reset: lst-ctn-kix_list_5-1 0;
+      }
+      ul.lst-kix_1qzjyx1qg1iy-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1qzjyx1qg1iy-1 {
+        list-style-type: none;
+      }
+      .lst-kix_8dk1wnpc6r4-6 > li {
+        counter-increment: lst-ctn-kix_8dk1wnpc6r4-6;
+      }
+      ul.lst-kix_1qzjyx1qg1iy-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_k6h9i77m7pz7-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1qzjyx1qg1iy-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_k6h9i77m7pz7-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1qzjyx1qg1iy-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_k6h9i77m7pz7-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_1qzjyx1qg1iy-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_k6h9i77m7pz7-6 {
+        list-style-type: none;
+      }
+      .lst-kix_n2t739nhbi13-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_1qzjyx1qg1iy-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_k6h9i77m7pz7-3 {
+        list-style-type: none;
+      }
+      .lst-kix_5uyckpqard-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_1qzjyx1qg1iy-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_k6h9i77m7pz7-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_d44mr7wbbmz9-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_d44mr7wbbmz9-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_d44mr7wbbmz9-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_d44mr7wbbmz9-3 {
+        list-style-type: none;
+      }
+      .lst-kix_coaitzo8e22o-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_d44mr7wbbmz9-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_d44mr7wbbmz9-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_d44mr7wbbmz9-6 {
+        list-style-type: none;
+      }
+      .lst-kix_t9ho1a2xas7j-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_d44mr7wbbmz9-7 {
+        list-style-type: none;
+      }
+      .lst-kix_list_3-8 > li {
+        counter-increment: lst-ctn-kix_list_3-8;
+      }
+      ul.lst-kix_d44mr7wbbmz9-8 {
+        list-style-type: none;
+      }
+      .lst-kix_list_4-6 > li {
+        counter-increment: lst-ctn-kix_list_4-6;
+      }
+      .lst-kix_list_1-5 > li {
+        counter-increment: lst-ctn-kix_list_1-5;
+      }
+      .lst-kix_vhc5oluvxxf3-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_list_4-2 > li:before {
+        content: "" counter(lst-ctn-kix_list_4-0, decimal) "."
+          counter(lst-ctn-kix_list_4-1, decimal) "."
+          counter(lst-ctn-kix_list_4-2, decimal) ". ";
+      }
+      .lst-kix_di21lnsh0r0l-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_21mtbyoilxak-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_gzdocpm58hz7-0 {
+        list-style-type: none;
+      }
+      .lst-kix_tn1l1rlq5s7-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_5ridsspeuiks-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_ys3df5ypy70p-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ys3df5ypy70p-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ys3df5ypy70p-5 {
+        list-style-type: none;
+      }
+      .lst-kix_18uiv6s2ma8s-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_ys3df5ypy70p-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ys3df5ypy70p-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ys3df5ypy70p-6 {
+        list-style-type: none;
+      }
+      .lst-kix_mcion8kv1fq2-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_zc802926avdh-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_ys3df5ypy70p-8 {
+        list-style-type: none;
+      }
+      .lst-kix_zhlek0m4ntir-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_ys3df5ypy70p-7 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_ys3df5ypy70p-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ys3df5ypy70p-0 {
+        list-style-type: none;
+      }
+      .lst-kix_k6h9i77m7pz7-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_eqlaut7noayk-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_list_1-6 > li:before {
+        content: "(" counter(lst-ctn-kix_list_1-6, lower-roman) ") ";
+      }
+      ul.lst-kix_nszccrumx3wm-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_nszccrumx3wm-7 {
+        list-style-type: none;
+      }
+      .lst-kix_6fsdo8k08r38-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ul.lst-kix_nszccrumx3wm-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_nszccrumx3wm-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_nszccrumx3wm-4 {
+        list-style-type: none;
+      }
+      .lst-kix_q4ylmkr5c9qa-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_u5xm10739dlx-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_nszccrumx3wm-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_gzdocpm58hz7-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_nszccrumx3wm-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_gzdocpm58hz7-8 {
+        list-style-type: none;
+      }
+      .lst-kix_list_2-2 > li:before {
+        content: "(" counter(lst-ctn-kix_list_2-2, lower-roman) ") ";
+      }
+      ul.lst-kix_nszccrumx3wm-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_gzdocpm58hz7-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_nszccrumx3wm-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_gzdocpm58hz7-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_gzdocpm58hz7-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_gzdocpm58hz7-4 {
+        list-style-type: none;
+      }
+      .lst-kix_7nvigrru0za7-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_list_5-2.start {
+        counter-reset: lst-ctn-kix_list_5-2 0;
+      }
+      ul.lst-kix_gzdocpm58hz7-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_gzdocpm58hz7-2 {
+        list-style-type: none;
+      }
+      ol {
+        margin: 0;
+        padding: 0;
+      }
+      table td,
+      table th {
+        padding: 0;
+      }
+      .c1 {
+        border-right-style: solid;
+        padding-top: 0pt;
+        border-top-width: 0pt;
+        border-right-width: 0pt;
+        padding-left: 0pt;
+        padding-bottom: 0pt;
+        line-height: 1.15;
+        border-left-width: 0pt;
+        border-top-style: solid;
+        background-color: #ffffff;
+        margin-left: 36pt;
+        border-left-style: solid;
+        border-bottom-width: 0pt;
+        border-bottom-style: solid;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+        padding-right: 0pt;
+      }
+      .c19 {
+        border-right-style: solid;
+        padding-top: 0pt;
+        border-top-width: 0pt;
+        border-right-width: 0pt;
+        padding-left: 0pt;
+        padding-bottom: 0pt;
+        line-height: 1.15;
+        border-left-width: 0pt;
+        border-top-style: solid;
+        background-color: #ffffff;
+        border-left-style: solid;
+        border-bottom-width: 0pt;
+        border-bottom-style: solid;
+        orphans: 2;
+        widows: 2;
+        text-align: center;
+        padding-right: 0pt;
+      }
+      .c8 {
+        border-right-style: solid;
+        padding-top: 0pt;
+        border-top-width: 0pt;
+        border-right-width: 0pt;
+        padding-left: 0pt;
+        padding-bottom: 0pt;
+        line-height: 1.15;
+        border-left-width: 0pt;
+        border-top-style: solid;
+        background-color: #ffffff;
+        border-left-style: solid;
+        border-bottom-width: 0pt;
+        border-bottom-style: solid;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+        padding-right: 0pt;
+      }
+      .c15 {
+        border-right-style: solid;
+        padding-top: 0pt;
+        border-top-width: 0pt;
+        border-right-width: 0pt;
+        padding-left: 0pt;
+        padding-bottom: 0pt;
+        line-height: 1.15;
+        border-top-style: solid;
+        margin-left: 54pt;
+        border-bottom-width: 0pt;
+        border-bottom-style: solid;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+        padding-right: 0pt;
+      }
+      .c5 {
+        border-right-style: solid;
+        padding-top: 0pt;
+        border-top-width: 0pt;
+        border-right-width: 0pt;
+        padding-left: 0pt;
+        padding-bottom: 0pt;
+        line-height: 1.15;
+        border-top-style: solid;
+        margin-left: 54pt;
+        border-bottom-width: 0pt;
+        border-bottom-style: solid;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+        padding-right: 0pt;
+      }
+      .c16 {
+        margin-left: 72pt;
+        padding-top: 10pt;
+        text-indent: -18pt;
+        padding-bottom: 10pt;
+        line-height: 1.1500000000000001;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+        height: 11pt;
+      }
+      .c21 {
+        color: #000000;
+        font-weight: 400;
+        text-decoration: none;
+        vertical-align: baseline;
+        font-size: 11pt;
+        font-family: "Arial";
+        font-style: normal;
+      }
+      .c6 {
+        color: #0000ff;
+        font-weight: 400;
+        text-decoration: none;
+        vertical-align: baseline;
+        font-size: 11pt;
+        font-family: "Calibri";
+        font-style: normal;
+      }
+      .c3 {
+        color: #000000;
+        font-weight: 700;
+        text-decoration: none;
+        vertical-align: baseline;
+        font-size: 11pt;
+        font-family: "Calibri";
+        font-style: normal;
+      }
+      .c11 {
+        color: #1c1e21;
+        font-weight: 400;
+        text-decoration: none;
+        vertical-align: baseline;
+        font-size: 11pt;
+        font-family: "Calibri";
+        font-style: normal;
+      }
+      .c4 {
+        color: #000000;
+        font-weight: 400;
+        text-decoration: none;
+        vertical-align: baseline;
+        font-size: 11pt;
+        font-family: "Calibri";
+        font-style: normal;
+      }
+      .c20 {
+        color: #1c1e21;
+        text-decoration: none;
+        vertical-align: baseline;
+        font-size: 11pt;
+        font-style: normal;
+      }
+      .c10 {
+        text-decoration-skip-ink: none;
+        font-family: "Calibri";
+        -webkit-text-decoration-skip: none;
+        font-weight: 400;
+        text-decoration: underline;
+      }
+      .c9 {
+        background-color: #ffffff;
+        max-width: 564pt;
+        padding: 24pt 24pt 24pt 24pt;
+      }
+      .c17 {
+        color: #1d1c1d;
+        font-weight: 400;
+        font-family: "Calibri";
+      }
+      .c12 {
+        color: #1c1e21;
+        font-weight: 400;
+        font-family: "Calibri";
+      }
+      .c18 {
+        font-weight: 400;
+        font-family: "Calibri";
+      }
+      .c7 {
+        font-weight: 700;
+        font-family: "Calibri";
+      }
+      .c0 {
+        color: inherit;
+        text-decoration: inherit;
+      }
+      .c2 {
+        padding: 0;
+        margin: 0;
+      }
+      .c14 {
+        color: #1155cc;
+      }
+      .c13 {
+        color: #0000ff;
+      }
+      .title {
+        padding-top: 24pt;
+        color: #000000;
+        font-weight: 700;
+        font-size: 11pt;
+        padding-bottom: 6pt;
+        font-family: "Arial";
+        line-height: 1.1500000000000001;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+      }
+      .subtitle {
+        padding-top: 18pt;
+        color: #666666;
+        font-size: 24pt;
+        padding-bottom: 4pt;
+        font-family: "Georgia";
+        line-height: 1.1500000000000001;
+        page-break-after: avoid;
+        font-style: italic;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+      }
+      li {
+        color: #000000;
+        font-size: 11pt;
+        font-family: "Arial";
+      }
+      p {
+        margin: 0;
+        color: #000000;
+        font-size: 11pt;
+        font-family: "Arial";
+      }
+      h1 {
+        padding-top: 10pt;
+        color: #000000;
+        font-weight: 700;
+        font-size: 11pt;
+        padding-bottom: 6pt;
+        font-family: "Arial";
+        line-height: 1.1500000000000001;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+      }
+      h2 {
+        padding-top: 18pt;
+        color: #000000;
+        font-weight: 700;
+        font-size: 18pt;
+        padding-bottom: 4pt;
+        font-family: "Arial";
+        line-height: 1.1500000000000001;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+      }
+      h3 {
+        padding-top: 18pt;
+        color: #000000;
+        font-weight: 700;
+        font-size: 11pt;
+        padding-bottom: 12pt;
+        font-family: "Arial";
+        line-height: 1.1666666666666667;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+      }
+      h4 {
+        padding-top: 12pt;
+        color: #000000;
+        font-weight: 700;
+        font-size: 11pt;
+        padding-bottom: 2pt;
+        font-family: "Arial";
+        line-height: 1.1500000000000001;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+      }
+      h5 {
+        padding-top: 11pt;
+        color: #000000;
+        font-weight: 700;
+        font-size: 11pt;
+        padding-bottom: 2pt;
+        font-family: "Arial";
+        line-height: 1.1500000000000001;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+      }
+      h6 {
+        padding-top: 10pt;
+        color: #000000;
+        font-weight: 700;
+        font-size: 10pt;
+        padding-bottom: 2pt;
+        font-family: "Arial";
+        line-height: 1.1500000000000001;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+      }
+    </style>
+  </head>
+  <body class="c9 doc-content">
+    <div>
+      <p class="c16"><span class="c21"></span></p>
+    </div>
+    <p class="c19">
+      <span class="c3">WEBSITE PRIVACY POLICY OF NEAR-INTENTS</span>
+    </p>
+    <p class="c8"><span class="c4">Updated as of 03.03.2025</span></p>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0 start" start="1">
+      <li class="c1 li-bullet-0"><span class="c3">About Us </span></li>
+    </ol>
+    <p class="c8">
+      <span class="c18">Aurora Labs Limited (&quot;</span
+      ><span class="c7"
+        >Company,&quot; &quot;we,&quot; &quot;us,&quot; or &quot;ou</span
+      ><span class="c18"
+        >r&quot;) values your privacy and We do our best effort to collect as
+        minimum as possible any Personal Data. This Privacy Policy outlines how
+        we handle data when you (&ldquo;</span
+      ><span class="c7">You&rdquo;, Yours&rdquo; or &ldquo;User</span
+      ><span class="c18"
+        >&rdquo;) access or use the following website-hosted user interfaces,
+        including but not limited to: </span
+      ><span class="c10 c14"
+        ><a
+          class="c0"
+          href="https://www.google.com/url?q=https://app.near-intents.org/&amp;sa=D&amp;source=editors&amp;ust=1741285646394009&amp;usg=AOvVaw3lZFB6eKYi9gWQcUPMhaSk"
+          >https://app.near-intents.org/</a
+        ></span
+      ><span class="c18">&nbsp;a.k.a. &ldquo;near-intents&rdquo; </span
+      ><span class="c10 c14"
+        ><a
+          class="c0"
+          href="https://www.google.com/url?q=https://solswap.org/&amp;sa=D&amp;source=editors&amp;ust=1741285646394203&amp;usg=AOvVaw3Zb1urM4xk7WAFEwefJqEh"
+          >https://solswap.org/</a
+        ></span
+      ><span class="c18">&nbsp;a.k.a. &ldquo;solswap&rdquo; </span
+      ><span class="c10 c14"
+        ><a
+          class="c0"
+          href="https://www.google.com/url?q=https://dogecoinswap.org/&amp;sa=D&amp;source=editors&amp;ust=1741285646394358&amp;usg=AOvVaw0l42BQsiT9WhNauZDjPLYe"
+          >https://dogecoinswap.org/</a
+        ></span
+      ><span class="c18">&nbsp; a.k.a. &quot;Dogecoinswap&quot;, </span
+      ><span class="c10 c14"
+        ><a
+          class="c0"
+          href="https://www.google.com/url?q=https://turboswap.org/&amp;sa=D&amp;source=editors&amp;ust=1741285646394504&amp;usg=AOvVaw0dzxIBrPAVpij4ywLB1oFv"
+          >https://turboswap.org/</a
+        ></span
+      ><span class="c18">&nbsp;a.k.a. &quot;Turboswap&quot;, </span
+      ><span class="c10 c14"
+        ><a
+          class="c0"
+          href="https://www.google.com/url?q=https://trump-swap.org/&amp;sa=D&amp;source=editors&amp;ust=1741285646394617&amp;usg=AOvVaw0egln4dsdDCvtxt2XtuZRv"
+          >https://trump-swap.org/</a
+        ></span
+      ><span class="c18">&nbsp;a.k.a. </span
+      ><span class="c17">&quot;Trumpswap&quot;, </span
+      ><span class="c18"
+        >(and all features available via the Interfaces). (the &quot;</span
+      ><span class="c7">Interfaces</span
+      ><span class="c18">&quot; or &ldquo;</span><span class="c7">Website</span
+      ><span class="c4"
+        >&rdquo;). The Interfaces provide access to the decentralized NEAR
+        Intents Protocol, which is not controlled or operated by the
+        Company.</span
+      >
+    </p>
+    <p class="c8">
+      <span class="c11"
+        >This Privacy Policy applies only to the Interface activities and is
+        valid for Users who are visitors to the Interface with regards to the
+        Personal Data that they share and/or which is collected within the
+        Interface. This Privacy Policy is not applicable to any Personal Data
+        collected offline or via channels other than the Interface. Please read
+        this Privacy Policy carefully to understand our policies and practices
+        regarding your data and how it will be treated by the Interface.</span
+      >
+    </p>
+    <p class="c8">
+      <span class="c11"
+        >IF YOU DO NOT HAVE THE RIGHT, POWER AND AUTHORITY TO ACT ON BEHALF OF
+        AND BIND THE BUSINESS, ORGANIZATION, OR OTHER ENTITY YOU REPRESENT,
+        PLEASE DO NOT ACCESS OR OTHERWISE USE THE INTERFACE.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c18"
+        >Unless otherwise specified in this Privacy Policy, the terms used here
+        have the same definitions as outlined in the UK GDPR (as defined in
+        section 3(10), as supplemented by section 205(4), of the UK&rsquo;s Data
+        Protection Act 2018) and the EU GDPR (General Data Protection Regulation
+        (EU) 2016/679)) &nbsp;(&quot;</span
+      ><span class="c7">GDPR</span><span class="c4">&quot;).</span>
+    </p>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="2">
+      <li class="c1 li-bullet-0">
+        <span class="c3">Changes to this Agreement</span>
+      </li>
+    </ol>
+    <p class="c8">
+      <span class="c12"
+        >If our data processing practices change, we will update this Privacy
+        Policy accordingly to let you know of them upfront and give you a
+        possibility to either provide your consent, object to a particular
+        processing, or undertake other action you are entitled to under the
+        Regulation. Please keep track of any changes we may introduce to this
+        Privacy Policy. Your continued access to and use of the Interface
+        constitutes your awareness of all amendments made to this Privacy Policy
+        as of the date of your accessing and use of the Interface. Therefore, we
+        encourage You to review this Privacy Policy regularly as you shall be
+        bound by it. If, for some reason, You are not satisfied with our
+        personal data processing practices, your immediate recourse is to stop
+        using the Interface. You do not have to inform us of this decision
+        unless you intend to exercise some of the data protection rights
+        stipulated by GDPR and defined below in this Privacy Policy.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="3">
+      <li class="c1 li-bullet-0"><span class="c3">&nbsp;Eligibility </span></li>
+    </ol>
+    <p class="c8">
+      <span class="c12"
+        >By accessing our Interface, you represent and warrant that you are at
+        least eighteen (18) years of age. If you are under the age of eighteen
+        (18), you may not, under any circumstances or for any reason, use the
+        Interface. Please report to us any instances involving the use of the
+        Interface by individuals under the age of 18, should they come to your
+        knowledge.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="4">
+      <li class="c1 li-bullet-0">
+        <span class="c3">Data Collection in connection with the Interface</span>
+      </li>
+    </ol>
+    <p class="c8">
+      <span class="c18"
+        >The Interfaces serve as a non-custodial tool that enables Users to
+        interact with the NEAR Intents Protocol (the &quot;</span
+      ><span class="c7">Protocol&quot;</span
+      ><span class="c4"
+        >), which operates independently from the Company.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c11"
+        >To the maximum extent possible, we try to collect as little Personal
+        Data from you as possible. Personal Data we collect:</span
+      >
+    </p>
+    <ul class="c2 lst-kix_5bxzw67pmq0j-0 start">
+      <li class="c1 li-bullet-0">
+        <span class="c11"
+          >IP address, MAC address, log files, domain server, data related to
+          usage, performance, website security, traffic patterns, location
+          information, browser and device information &ndash; only when you are
+          using the Interface;</span
+        >
+      </li>
+      <li class="c1 li-bullet-0">
+        <span class="c11"
+          >Wallet addresses (public blockchain addresses), transaction, and
+          balance information (blockchain data) that is accessible when
+          interacting with the Interface; The legal basis for this processing is
+          our legitimate interests, such as monitoring and improving the
+          Interface, the proper protection of the Interface against risks, and
+          partly the contract performance basis to provide you the Interface.
+          Note that we are not responsible for your use of any of the blockchain
+          and your data processed in these decentralized and permissionless
+          networks;</span
+        >
+      </li>
+    </ul>
+    <p class="c8">
+      <span class="c11"
+        >The Company may, but is not obliged to, engage third-parties
+        advertising platforms that are triggered only when their technical
+        features (so-called &ldquo;pixels&rdquo;) are enabled through the
+        Interface. The mentioned third-parties advertising platforms may collect
+        Personal Data of Interface&#39;s visitors only with the purpose to
+        optimize their advertising possibilities through their platforms, target
+        you with their advertisements, and possibly share your data with other
+        advertising platforms and agencies for further use. The Company
+        &nbsp;may engage with the mentioned Personal Data of Interfaces
+        visitors.</span
+      >
+    </p>
+    <p class="c8">
+      <span class="c11"
+        >In no event, are we going to ask you to share your private keys or
+        wallet seed. Never trust anyone or any website that asks you to enter
+        your private keys or wallet seed.</span
+      >
+    </p>
+    <p class="c8">
+      <span class="c20 c7">Why we may use your personal data</span>
+    </p>
+    <p class="c8">
+      <span class="c11"
+        >To clear any doubts, we may use Personal Data described above or any
+        other Personal Data:</span
+      >
+    </p>
+    <ul class="c2 lst-kix_f9961645pj1n-0 start">
+      <li class="c1 li-bullet-0">
+        <span class="c11"
+          >on the basis of contract performance or necessity to enter into a
+          contract (where the Personal Data is required for us to perform our
+          undertakings and obligations in accordance with a contract we are
+          entering into when you use our services, or where we are at the
+          negotiations phase);</span
+        >
+      </li>
+      <li class="c1 li-bullet-0">
+        <span class="c11"
+          >on the basis of our or our processors&rsquo; legitimate interests to
+          protect the Interface, prevent any malicious and harmful activities to
+          the Interface, maintain our technical systems healthily and secure,
+          improve services and products by using aggregate statistics;</span
+        >
+      </li>
+      <li class="c1 li-bullet-0">
+        <span class="c11"
+          >to respond to legal requests of authorities, provide information upon
+          court orders and judgments, or if we have a good-faith belief that
+          such disclosure is necessary in order to comply with official
+          investigations or legal proceedings initiated by governmental and/or
+          law enforcement officials, or private parties, including but not
+          limited to: in response to subpoenas, search warrants or court orders,
+          and including other similar statutory obligations we or our processors
+          are subjected to;</span
+        >
+      </li>
+      <li class="c1 li-bullet-0">
+        <span class="c11">on the basis of your consent; and</span>
+      </li>
+      <li class="c1 li-bullet-0">
+        <span class="c11"
+          >on other legal bases set forth in the personal data protection
+          laws.</span
+        >
+      </li>
+    </ul>
+    <p class="c8"><span class="c20 c7">Disclosure of Data</span></p>
+    <p class="c8">
+      <span class="c11"
+        >In continuation of legal bases for collecting and processing the
+        Personal Data, We may disclose any Personal Data about you:</span
+      >
+    </p>
+    <ul class="c2 lst-kix_m6fvupggs9zx-0 start">
+      <li class="c1 li-bullet-0">
+        <span class="c11"
+          >in connection with a merger, division, restructuring, or other
+          association change; or</span
+        >
+      </li>
+      <li class="c1 li-bullet-0">
+        <span class="c11"
+          >to our subsidiaries or affiliates (if any) only if necessary for
+          operational purposes. If we must disclose any of your Personal Data in
+          order to comply with official investigations or legal proceedings
+          initiated by governmental and/or law enforcement officials, we may not
+          be able to ensure that such recipients of your Personal Data will
+          maintain the privacy or security of your Personal Data.</span
+        >
+      </li>
+    </ul>
+    <p class="c8"><span class="c7 c20">Data Retention Period</span></p>
+    <p class="c8">
+      <span class="c11"
+        >The Company maintains Personal Data exclusively within the time needed
+        to follow prescribed herein legal purposes. When we no longer need
+        Personal Data, the limitation period for storage of such Personal Data
+        has expired, you have withdrawn your consent or objected to our or our
+        processors&rsquo; legitimate interests, we securely delete or destroy it
+        unless the statutory requirements we, our processors or other
+        controllers are subjected to stipulate otherwise. Aggregated data, which
+        cannot directly identify a device/browser (or individual) and is used
+        for purposes of reporting and analysis, is maintained for as long as
+        commercially necessary till you object to the processing of such data or
+        withdraw your consent.</span
+      >
+    </p>
+    <p class="c8">
+      <span class="c11"
+        >Sometimes legal requirements oblige us to retain certain data, for
+        specific purposes, for an extended period of time. Reasons we might
+        retain some data for longer periods of time include:</span
+      >
+    </p>
+    <ul class="c2 lst-kix_n81gzgxe38yj-0 start">
+      <li class="c1 li-bullet-0">
+        <span class="c11">Security, fraud &amp; abuse prevention;</span>
+      </li>
+      <li class="c1 li-bullet-0">
+        <span class="c11">Financial monitoring and record-keeping;</span>
+      </li>
+      <li class="c1 li-bullet-0">
+        <span class="c11"
+          >Complying with legal or regulatory requirements;</span
+        >
+      </li>
+      <li class="c1 li-bullet-0">
+        <span class="c12"
+          >Ensuring the continuity of your interaction with the Interface.</span
+        >
+      </li>
+    </ul>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="5">
+      <li class="c1 li-bullet-0">
+        <span class="c3">Cookies and similar technologies </span>
+      </li>
+    </ol>
+    <p class="c8">
+      <span class="c18"
+        >Our Website uses cookies and similar technologies (collectively
+        &ldquo;</span
+      ><span class="c7">tools</span
+      ><span class="c4"
+        >&rdquo;) provided either by us or by third parties.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >A cookie is a small text file stored on your device by your browser.
+        They are useful since they allow us to recognize your device, in order
+        for our Website to work properly or more efficiently. They can also be
+        used to provide information to the owners of websites on how users
+        engage with them. Without cookies or some other similar technology (e.g.
+        web storage, fingerprints, tags, or pixels), we would have no way of
+        &#39;remembering&#39; our visitors. While most browsers accept these by
+        default, you can adjust settings to reject or store them only with your
+        consent. Refusing may impact your ability to use our Website seamlessly.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >In addition, we also use temporary cookies that are stored on your end
+        device to optimize user-friendliness. If you visit our platform again to
+        use our services, it will automatically recognize that you have already
+        been with us and what entries and settings you have made so that you do
+        not have to enter them again.</span
+      >
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >Furthermore, we use cookies to statistically record the use of our
+        Platform and to evaluate it for you for optimizing our Platform and
+        further marketing. These cookies enable us to automatically recognize
+        when you return to our Platform that you have already been with
+        us.</span
+      >
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >The data processed by cookies for the aforementioned purposes is
+        justified to protect our legitimate interests and those of third
+        parties.</span
+      >
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >Most browsers automatically accept cookies. However, you can configure
+        your browser so that no cookies are stored on your computer or a message
+        always appears before a new cookie is created. However, the complete
+        deactivation of cookies can lead to the fact that you cannot use all
+        functions of our Platform.</span
+      >
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >We use Google Analytics on our Platform. These are services provided by
+        third parties, which may be located in any country (Google LLC is based
+        in the US but Google Ireland Ltd. is the data controller for customers
+        based in the EU, for more information visit
+        https://policies.google.com/?hl=en) and allow us to measure and evaluate
+        the use of our Platform (without identifying individuals). Permanent
+        cookies, which are placed by the service provider, are also used for
+        this purpose. Although such service providers do not receive personal
+        data from us (and do not retain any IP addresses), they may track your
+        use of the Platform, combine this information with data from other
+        websites you have visited, which are also tracked by service providers,
+        and use this information for their own purposes (e.g. to manage to
+        advertise). If you have registered with the service provider concerned,
+        the service provider will also know your identity. The service provider
+        concerned will then be responsible for processing your personal data by
+        the applicable data protection provisions. Service providers only
+        provide information on how a particular website is used (but not any
+        personal details).</span
+      >
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >We also use plugins from social networks such as Facebook, Twitter,
+        YouTube, Google+, and LinkedIn on our Platform. This will be evident to
+        you, as the relevant symbol will typically be displayed. We have
+        configured these elements to be disabled by default. If you enable these
+        (by clicking on them), the social network operators may register that
+        you are on our website and where you are on our website and may use this
+        information for their purposes. The operator concerned will then be
+        responsible for processing your personal data by the applicable data
+        protection provisions. We will not receive any information regarding you
+        from the operator concerned.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="6">
+      <li class="c1 li-bullet-0">
+        <span class="c3">Third-party apps and websites </span>
+      </li>
+    </ol>
+    <p class="c8">
+      <span class="c4"
+        >Our Website may contains links to websites or apps that are not
+        operated by us. When you click on a third-party link, you will be
+        directed to that third-party&#39;s website or app. We have no control
+        over the content, privacy policies, or practices of any of these third
+        parties.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >We maintain a presence on social networks to communicate with you, our
+        clients, and prospective clients, as well as to provide information
+        about our Program, products, and services. If you have an account on the
+        same network, it is possible that your information and media are made
+        available to us, for example, when we access your profile.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >As soon as we transfer personal data into our own system, we are
+        responsible for this independently. This is done to carry out
+        pre-contractual steps or to fulfill a contract with you.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >Below is the list of social networks on which we are present:
+      </span>
+    </p>
+    <ul class="c2 lst-kix_t9ho1a2xas7j-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c18">Discord:</span
+        ><span class="c18"
+          ><a
+            class="c0"
+            href="https://www.google.com/url?q=https://discord.com/privacy&amp;sa=D&amp;source=editors&amp;ust=1741285646400510&amp;usg=AOvVaw2bbyqk-_bAxBmo6jKwfheC"
+            >&nbsp;</a
+          ></span
+        ><span class="c10 c13"
+          ><a
+            class="c0"
+            href="https://www.google.com/url?q=https://discord.com/privacy&amp;sa=D&amp;source=editors&amp;ust=1741285646400642&amp;usg=AOvVaw1T5US1AlLccJ5tlPab_B_E"
+            >Privacy policy</a
+          ></span
+        ><span class="c18 c13">;</span><span class="c4">&nbsp;</span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_zhlek0m4ntir-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c18">Telegram:</span
+        ><span class="c18"
+          ><a
+            class="c0"
+            href="https://www.google.com/url?q=https://telegram.org/privacy/eu&amp;sa=D&amp;source=editors&amp;ust=1741285646400885&amp;usg=AOvVaw3O8HdYnwVtTpSKoQsA7yax"
+            >&nbsp;</a
+          ></span
+        ><span class="c10 c13"
+          ><a
+            class="c0"
+            href="https://www.google.com/url?q=https://telegram.org/privacy/eu&amp;sa=D&amp;source=editors&amp;ust=1741285646400972&amp;usg=AOvVaw0Jn847fOwU7Acrvbmx4SUa"
+            >Privacy policy</a
+          ></span
+        ><span class="c6">; </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_z0lw2b2aattg-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c18">X:</span
+        ><span class="c18"
+          ><a
+            class="c0"
+            href="https://www.google.com/url?q=https://x.com/en/privacy&amp;sa=D&amp;source=editors&amp;ust=1741285646401160&amp;usg=AOvVaw2PFRwcXkGvW18AcZDng5Vu"
+            >&nbsp;</a
+          ></span
+        ><span class="c10 c13"
+          ><a
+            class="c0"
+            href="https://www.google.com/url?q=https://x.com/en/privacy&amp;sa=D&amp;source=editors&amp;ust=1741285646401236&amp;usg=AOvVaw1lyt8k5Ucnwy3Q9ESpsnTX"
+            >Privacy policy</a
+          ></span
+        ><span class="c6">; </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_7nvigrru0za7-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c18">YouTube:</span
+        ><span class="c18"
+          ><a
+            class="c0"
+            href="https://www.google.com/url?q=https://policies.google.com/privacy&amp;sa=D&amp;source=editors&amp;ust=1741285646401432&amp;usg=AOvVaw3eFiHSrmmbaaNd0iMASf5_"
+            >&nbsp;</a
+          ></span
+        ><span class="c10 c13"
+          ><a
+            class="c0"
+            href="https://www.google.com/url?q=https://policies.google.com/privacy&amp;sa=D&amp;source=editors&amp;ust=1741285646401524&amp;usg=AOvVaw3XikONAGrxII45cmQJiack"
+            >Privacy policy</a
+          ></span
+        ><span class="c6">. </span>
+      </li>
+    </ul>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="7">
+      <li class="c1 li-bullet-0">
+        <span class="c3">For how long do we store personal data </span>
+      </li>
+    </ol>
+    <p class="c8">
+      <span class="c4"
+        >We retain personal data for the period necessary to fulfill the
+        purposes for which it was collected, in accordance with the legal,
+        regulatory and contractual obligations to which we are subject. Once
+        this retention period is over, we delete the personal data or
+        irreversibly anonymize it.
+      </span>
+    </p>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="8">
+      <li class="c1 li-bullet-0">
+        <span class="c3">With whom we share personal data </span>
+      </li>
+    </ol>
+    <p class="c8"><span class="c3">Our service providers </span></p>
+    <p class="c8">
+      <span class="c18">We collaborate with third-party entities (&quot;</span
+      ><span class="c7">service providers</span
+      ><span class="c4"
+        >&quot;) to support the functioning of our Website. These service
+        providers assist in various activities, such as analyzing service usage,
+        facilitating payments, and providing IT infrastructure. They are granted
+        access to your personal data solely to the extent required to carry out
+        these tasks.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >Categories of service providers that can access your personal data:
+      </span>
+    </p>
+    <ul class="c2 lst-kix_1roqjrv0u415-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4"
+          >Cloud service, hosting and infrastructure providers;
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_z4hxpql0fcdo-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4">E-mailing service providers; </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_tf0geodn37sd-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4">Advertising and affiliate networks; </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_ys3df5ypy70p-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4">IT and security services; </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_mcion8kv1fq2-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4">Social media and content platforms; </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_88zd2c7m8zo2-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4"
+          >Professional advisers we use, such as accountants and lawyers;
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_di21lnsh0r0l-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4"
+          >Other group entities that are involved in your matter.
+        </span>
+      </li>
+    </ul>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="9">
+      <li class="c1 li-bullet-0">
+        <span class="c3">Third-Country Transfers </span>
+      </li>
+    </ol>
+    <p class="c8">
+      <span class="c4"
+        >Please note that we process personal data and hire service providers
+        located in countries outside the EU/EEA. These third countries may not
+        offer a level of data protection equivalent to that of the EU/EEA.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >To ensure the security of your personal data during these transfers, we
+        fulfill applicable legal obligations by adopting appropriate safeguards.
+        These safeguards include:
+      </span>
+    </p>
+    <ul class="c2 lst-kix_q4ylmkr5c9qa-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4"
+          >Transfer of data to countries that have received an adequacy decision
+          from the European Commission.
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_nszccrumx3wm-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c18"
+          >Implementation of standard contractual clauses provided by the
+          European Commission, in accordance with</span
+        ><span class="c18"
+          ><a
+            class="c0"
+            href="https://www.google.com/url?q=https://eur-lex.europa.eu/eli/dec_impl/2021/914/oj&amp;sa=D&amp;source=editors&amp;ust=1741285646403208&amp;usg=AOvVaw2q5-e9GKHNf3ZqRWKnzZK6"
+            >&nbsp;</a
+          ></span
+        ><span class="c10"
+          ><a
+            class="c0"
+            href="https://www.google.com/url?q=https://eur-lex.europa.eu/eli/dec_impl/2021/914/oj&amp;sa=D&amp;source=editors&amp;ust=1741285646403358&amp;usg=AOvVaw3WcmcuMOjPfpIHOkfJEwzD"
+            >Commission Implementing Decision (EU) 2021/914 of 4 June 2021</a
+          ></span
+        ><span class="c4"
+          >, as well as supplementary measures for the transfer, where we
+          consider that such measures are necessary to guarantee a level of
+          protection essentially equivalent to that of the EU.
+        </span>
+      </li>
+    </ul>
+    <p class="c8">
+      <span class="c4"
+        >In the event of a transfer to a third country where adequacy decisions
+        or appropriate safeguards are absent, it is conceivable that authorities
+        in the third country, such as intelligence services, could access the
+        transferred data. Consequently, the enforceability of your data subject
+        rights may not be guaranteed.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >We and/or our service providers transfer your personal data to and
+        process it in countries outside the EU/EEA. These countries include:
+      </span>
+    </p>
+    <ul class="c2 lst-kix_eqlaut7noayk-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4">United States of America; </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_afzuvuipsb6i-0 start">
+      <li class="c15 li-bullet-0"><span class="c4">United Kingdom. </span></li>
+    </ul>
+    <p class="c8">
+      <span class="c18"
+        >In cases where the transfer to a third country is based on the use of
+        standard contractual clauses provided by the European Commission, you
+        have the right to request a copy of the clauses under which your
+        personal data is transferred to a third country. However, the contract
+        may be redacted in those parts that must remain confidential (i.e. other
+        people&#39;s personal data). You can request the applicable copies by
+        contacting: </span
+      ><span class="c10 c14"
+        ><a class="c0" href="mailto:support@aurora.dev"
+          >support@aurora.dev</a
+        ></span
+      ><span class="c4">&nbsp;. </span>
+    </p>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="10">
+      <li class="c1 li-bullet-0"><span class="c3">Data Disclosure </span></li>
+    </ol>
+    <p class="c8">
+      <span class="c4"
+        >We may disclose your personal data when we have a sincere belief that
+        such disclosure is essential for the following purposes:
+      </span>
+    </p>
+    <ul class="c2 lst-kix_k6h9i77m7pz7-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4"
+          >To fulfil a legal obligation, which includes cases where such
+          disclosure is required by law or in response to lawful requests from
+          public authorities, such as a court or a government agency.
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_jpvy5hdtq2p3-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4"
+          >To safeguard the security of our services and safeguard our rights or
+          property.
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_wwx8zpyq2pae-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4"
+          >To prevent or investigate potential unlawful conduct related to our
+          operations.
+        </span>
+      </li>
+    </ul>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="11">
+      <li class="c1 li-bullet-0">
+        <span class="c3">How we keep personal data safe </span>
+      </li>
+    </ol>
+    <p class="c8">
+      <span class="c4"
+        >We implement reasonable technical and organizational security measures
+        that we consider appropriate to safeguard your stored personal data from
+        manipulation, loss, or unauthorized access by third parties. Our
+        security measures are continuously updated to align with advancements in
+        technology.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >We place significant emphasis on internal data privacy. Our staff and
+        engaged service providers are bound by confidentiality and must comply
+        with relevant data protection laws. Moreover, they are granted access to
+        personal data only to the extent necessary for the performance of their
+        respective duties or obligations.
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c4"
+        >We value the security of your personal data; however, please bear in
+        mind that no method of transmitting data over the internet or electronic
+        storage can be guaranteed 100% secure. While we make every effort to
+        employ commercially reasonable measures to protect your personal data,
+        we cannot provide absolute security. We recommend employing antivirus
+        software, firewalls, and similar tools to enhance the protection of your
+        system.
+      </span>
+    </p>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="12">
+      <li class="c1 li-bullet-0"><span class="c3">Your Rights </span></li>
+    </ol>
+    <p class="c8">
+      <span class="c18"
+        >You possess the following data protection rights. To exercise these
+        rights, please reach out to us at the provided address or send an email
+        to </span
+      ><span class="c10 c14"
+        ><a class="c0" href="mailto:support@aurora.dev"
+          >support@aurora.dev</a
+        ></span
+      ><span class="c18">&nbsp;or </span
+      ><span class="c10 c14"
+        ><a class="c0" href="mailto:legal@aurora.dev">legal@aurora.dev</a></span
+      ><span class="c18">.</span
+      ><span class="c4"
+        >&nbsp;Please be aware that we may ask you to verify your identity
+        before addressing your requests.
+      </span>
+    </p>
+    <ul class="c2 lst-kix_ew66vvnubm3e-0 start">
+      <li class="c15 li-bullet-0">
+        <span class="c4"
+          >Right to Access: You have the right to request a copy of your
+          personal data, which we will furnish to you in an electronic format.
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_23dxydqlwhcr-0 start">
+      <li class="c5 li-bullet-0">
+        <span class="c4"
+          >Right to Correction: You can request us to rectify any inaccuracies
+          or incompleteness in your data.
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_vhc5oluvxxf3-0 start">
+      <li class="c5 li-bullet-0">
+        <span class="c4"
+          >Right to Withdraw Consent: If you&#39;ve given your consent for the
+          processing of your personal data, you have the right to withdraw it at
+          any time, affecting future processing. This applies, for example, when
+          you wish to opt out of marketing communications. Once we receive your
+          withdrawal of consent, we will no longer process your information for
+          the purpose(s) you initially consented to, unless there exists another
+          legal basis for processing.
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_6852xf81qh5h-0 start">
+      <li class="c5 li-bullet-0">
+        <span class="c4"
+          >Right to Erasure: You have the right to request the deletion of your
+          personal data when it is no longer necessary for the purposes it was
+          collected, or if it was processed unlawfully.
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_5uyckpqard-0 start">
+      <li class="c5 li-bullet-0">
+        <span class="c4"
+          >Right to Restrict Processing: You can request the limitation of our
+          processing of your personal data in cases where you believe it to be
+          inaccurate, processed unlawfully, or no longer needed for the original
+          purpose, but cannot be deleted due to legal obligations or your own
+          request.
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_e5mhrzfnma4q-0 start">
+      <li class="c5 li-bullet-0">
+        <span class="c4"
+          >Right to Data Portability: You can request that we transmit your
+          personal data to another data controller in a standard format (e.g.,
+          Excel), if you provided this data to us and we processed it based on
+          your consent or to fulfill contractual obligations.
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_xwvuqm5td0w4-0 start">
+      <li class="c5 li-bullet-0">
+        <span class="c4"
+          >Right to Object to Processing: If the legal basis for processing your
+          personal data is our legitimate interest, you have the right to object
+          to such processing based on your specific situation. We will respect
+          your request, unless we have a compelling legal basis for the
+          processing that outweighs your interests or if we need to continue
+          processing the data for legal defense purposes.
+        </span>
+      </li>
+    </ul>
+    <ul class="c2 lst-kix_u5xm10739dlx-0 start">
+      <li class="c5 li-bullet-0">
+        <span class="c4"
+          >Right to File a Complaint with a Supervisory Authority: If you
+          believe that the processing of your personal data violates data
+          protection laws, you have the right to lodge a complaint with a data
+          protection supervisory authority. In the EU and EEA, you can exercise
+          this right by contacting a supervisory authority in your country of
+          residence, workplace, or where you believe the infringement occurred.
+          You can find a list of the relevant authorities here:
+          https://edpb.europa.eu/about-edpb/about-edpb/members.
+        </span>
+      </li>
+    </ul>
+    <p class="c8">
+      <span class="c18"
+        >We will respond to your requests within 30 days of receiving them. This
+        response period may be extended if the request is particularly complex,
+        which we will inform you of promptly. Within this period, we will
+        respond to your request or inform you of the reasons why your request
+        cannot be met.
+      </span>
+    </p>
+    <ol class="c2 lst-kix_8dk1wnpc6r4-0" start="13">
+      <li class="c1 li-bullet-0"><span class="c3">Contact Us </span></li>
+    </ol>
+    <p class="c8">
+      <span class="c4"
+        >If you have any inquiries or concerns regarding this Privacy Policy,
+        please do not hesitate to contact us at:
+      </span>
+    </p>
+    <p class="c8"><span class="c4">Aurora Labs Limited </span></p>
+    <p class="c8">
+      <span class="c4"
+        >Madison Building, Midtown, Queensway, Gibraltar, GX11 1AA
+      </span>
+    </p>
+    <p class="c8">
+      <span class="c10 c14"
+        ><a class="c0" href="mailto:support@aurora.dev"
+          >support@aurora.dev</a
+        ></span
+      ><span class="c18">&nbsp; or </span
+      ><span class="c10 c14"
+        ><a class="c0" href="mailto:legal@aurora.dev">legal@aurora.dev</a></span
+      ><span class="c18">&nbsp;</span>
+    </p>
+  </body>
+</html>

--- a/public/static/documents/terms-of-service.html
+++ b/public/static/documents/terms-of-service.html
@@ -1,0 +1,3167 @@
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="content-type" />
+    <style type="text/css">
+      .lst-kix_j73m0ayaholw-8 > li:before {
+        content: "" counter(lst-ctn-kix_j73m0ayaholw-8, lower-roman) ". ";
+      }
+      ol.lst-kix_q2k6dq6ukorq-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8uyd1khpfw5h-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_q2k6dq6ukorq-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_q2k6dq6ukorq-6 {
+        list-style-type: none;
+      }
+      ol.lst-kix_q2k6dq6ukorq-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_q2k6dq6ukorq-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_tczx9grtlag8-1.start {
+        counter-reset: lst-ctn-kix_tczx9grtlag8-1 0;
+      }
+      ol.lst-kix_8uyd1khpfw5h-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_q2k6dq6ukorq-3 {
+        list-style-type: none;
+      }
+      .lst-kix_8uyd1khpfw5h-2 > li {
+        counter-increment: lst-ctn-kix_8uyd1khpfw5h-2;
+      }
+      ol.lst-kix_8uyd1khpfw5h-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_q2k6dq6ukorq-2 {
+        list-style-type: none;
+      }
+      ol.lst-kix_ciyq8h2db8dp-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8uyd1khpfw5h-2 {
+        list-style-type: none;
+      }
+      .lst-kix_j73m0ayaholw-6 > li:before {
+        content: "" counter(lst-ctn-kix_j73m0ayaholw-6, decimal) ". ";
+      }
+      ol.lst-kix_q2k6dq6ukorq-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8uyd1khpfw5h-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_q2k6dq6ukorq-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8uyd1khpfw5h-8 {
+        list-style-type: none;
+      }
+      .lst-kix_j73m0ayaholw-7 > li:before {
+        content: "" counter(lst-ctn-kix_j73m0ayaholw-7, lower-latin) ". ";
+      }
+      ol.lst-kix_ciyq8h2db8dp-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8uyd1khpfw5h-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_ciyq8h2db8dp-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8uyd1khpfw5h-6 {
+        list-style-type: none;
+      }
+      ol.lst-kix_t0bmnl9bsu28-0.start {
+        counter-reset: lst-ctn-kix_t0bmnl9bsu28-0 0;
+      }
+      ol.lst-kix_ciyq8h2db8dp-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8uyd1khpfw5h-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_ciyq8h2db8dp-2 {
+        list-style-type: none;
+      }
+      ol.lst-kix_q2k6dq6ukorq-4.start {
+        counter-reset: lst-ctn-kix_q2k6dq6ukorq-4 0;
+      }
+      ol.lst-kix_fmh85vykfuhc-2.start {
+        counter-reset: lst-ctn-kix_fmh85vykfuhc-2 0;
+      }
+      ol.lst-kix_ciyq8h2db8dp-5.start {
+        counter-reset: lst-ctn-kix_ciyq8h2db8dp-5 0;
+      }
+      .lst-kix_fmh85vykfuhc-1 > li {
+        counter-increment: lst-ctn-kix_fmh85vykfuhc-1;
+      }
+      .lst-kix_j73m0ayaholw-6 > li {
+        counter-increment: lst-ctn-kix_j73m0ayaholw-6;
+      }
+      ol.lst-kix_8uyd1khpfw5h-4.start {
+        counter-reset: lst-ctn-kix_8uyd1khpfw5h-4 0;
+      }
+      ol.lst-kix_fmh85vykfuhc-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_fmh85vykfuhc-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_fmh85vykfuhc-6 {
+        list-style-type: none;
+      }
+      ol.lst-kix_fmh85vykfuhc-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_fmh85vykfuhc-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_fmh85vykfuhc-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_tczx9grtlag8-7.start {
+        counter-reset: lst-ctn-kix_tczx9grtlag8-7 0;
+      }
+      .lst-kix_8uyd1khpfw5h-4 > li {
+        counter-increment: lst-ctn-kix_8uyd1khpfw5h-4;
+      }
+      .lst-kix_j73m0ayaholw-1 > li:before {
+        content: "" counter(lst-ctn-kix_j73m0ayaholw-1, lower-latin) ". ";
+      }
+      .lst-kix_j73m0ayaholw-4 > li {
+        counter-increment: lst-ctn-kix_j73m0ayaholw-4;
+      }
+      ol.lst-kix_ciyq8h2db8dp-7 {
+        list-style-type: none;
+      }
+      .lst-kix_tczx9grtlag8-7 > li {
+        counter-increment: lst-ctn-kix_tczx9grtlag8-7;
+      }
+      ol.lst-kix_ciyq8h2db8dp-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_fmh85vykfuhc-8.start {
+        counter-reset: lst-ctn-kix_fmh85vykfuhc-8 0;
+      }
+      .lst-kix_j73m0ayaholw-0 > li:before {
+        content: "" counter(lst-ctn-kix_j73m0ayaholw-0, decimal) ". ";
+      }
+      .lst-kix_j73m0ayaholw-2 > li:before {
+        content: "" counter(lst-ctn-kix_j73m0ayaholw-2, lower-roman) ". ";
+      }
+      ol.lst-kix_ciyq8h2db8dp-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_ciyq8h2db8dp-6 {
+        list-style-type: none;
+      }
+      .lst-kix_hy5l3i205ziq-8 > li {
+        counter-increment: lst-ctn-kix_hy5l3i205ziq-8;
+      }
+      ul.lst-kix_uklpstvt09kj-8 {
+        list-style-type: none;
+      }
+      .lst-kix_j73m0ayaholw-5 > li:before {
+        content: "" counter(lst-ctn-kix_j73m0ayaholw-5, lower-roman) ". ";
+      }
+      ul.lst-kix_uklpstvt09kj-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_uklpstvt09kj-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_j73m0ayaholw-3.start {
+        counter-reset: lst-ctn-kix_j73m0ayaholw-3 0;
+      }
+      .lst-kix_j73m0ayaholw-4 > li:before {
+        content: "" counter(lst-ctn-kix_j73m0ayaholw-4, lower-latin) ". ";
+      }
+      ul.lst-kix_uklpstvt09kj-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_uklpstvt09kj-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_fmh85vykfuhc-0 {
+        list-style-type: none;
+      }
+      .lst-kix_j73m0ayaholw-3 > li:before {
+        content: "" counter(lst-ctn-kix_j73m0ayaholw-3, decimal) ". ";
+      }
+      ul.lst-kix_uklpstvt09kj-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_uklpstvt09kj-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_fmh85vykfuhc-2 {
+        list-style-type: none;
+      }
+      ul.lst-kix_uklpstvt09kj-2 {
+        list-style-type: none;
+      }
+      ol.lst-kix_fmh85vykfuhc-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_uklpstvt09kj-3 {
+        list-style-type: none;
+      }
+      .lst-kix_ciyq8h2db8dp-5 > li {
+        counter-increment: lst-ctn-kix_ciyq8h2db8dp-5;
+      }
+      ol.lst-kix_8uyd1khpfw5h-3.start {
+        counter-reset: lst-ctn-kix_8uyd1khpfw5h-3 0;
+      }
+      ol.lst-kix_t0bmnl9bsu28-5.start {
+        counter-reset: lst-ctn-kix_t0bmnl9bsu28-5 0;
+      }
+      ol.lst-kix_t0bmnl9bsu28-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_ciyq8h2db8dp-0.start {
+        counter-reset: lst-ctn-kix_ciyq8h2db8dp-0 0;
+      }
+      ol.lst-kix_j73m0ayaholw-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_j73m0ayaholw-4 {
+        list-style-type: none;
+      }
+      .lst-kix_fmh85vykfuhc-5 > li {
+        counter-increment: lst-ctn-kix_fmh85vykfuhc-5;
+      }
+      ol.lst-kix_j73m0ayaholw-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_j73m0ayaholw-2 {
+        list-style-type: none;
+      }
+      ol.lst-kix_j73m0ayaholw-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_j73m0ayaholw-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_j73m0ayaholw-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_j73m0ayaholw-6 {
+        list-style-type: none;
+      }
+      ol.lst-kix_j73m0ayaholw-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_hy5l3i205ziq-3.start {
+        counter-reset: lst-ctn-kix_hy5l3i205ziq-3 0;
+      }
+      ol.lst-kix_t0bmnl9bsu28-2 {
+        list-style-type: none;
+      }
+      ol.lst-kix_t0bmnl9bsu28-1 {
+        list-style-type: none;
+      }
+      .lst-kix_hy5l3i205ziq-6 > li {
+        counter-increment: lst-ctn-kix_hy5l3i205ziq-6;
+      }
+      ol.lst-kix_t0bmnl9bsu28-4 {
+        list-style-type: none;
+      }
+      ol.lst-kix_t0bmnl9bsu28-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_t0bmnl9bsu28-6 {
+        list-style-type: none;
+      }
+      .lst-kix_q2k6dq6ukorq-6 > li {
+        counter-increment: lst-ctn-kix_q2k6dq6ukorq-6;
+      }
+      ol.lst-kix_t0bmnl9bsu28-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_j73m0ayaholw-4.start {
+        counter-reset: lst-ctn-kix_j73m0ayaholw-4 0;
+      }
+      .lst-kix_ciyq8h2db8dp-0 > li {
+        counter-increment: lst-ctn-kix_ciyq8h2db8dp-0;
+      }
+      ol.lst-kix_t0bmnl9bsu28-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_t0bmnl9bsu28-7 {
+        list-style-type: none;
+      }
+      .lst-kix_j73m0ayaholw-2 > li {
+        counter-increment: lst-ctn-kix_j73m0ayaholw-2;
+      }
+      ol.lst-kix_hy5l3i205ziq-4.start {
+        counter-reset: lst-ctn-kix_hy5l3i205ziq-4 0;
+      }
+      ol.lst-kix_tczx9grtlag8-2.start {
+        counter-reset: lst-ctn-kix_tczx9grtlag8-2 0;
+      }
+      .lst-kix_t0bmnl9bsu28-0 > li {
+        counter-increment: lst-ctn-kix_t0bmnl9bsu28-0;
+      }
+      ol.lst-kix_fmh85vykfuhc-3.start {
+        counter-reset: lst-ctn-kix_fmh85vykfuhc-3 0;
+      }
+      .lst-kix_j73m0ayaholw-8 > li {
+        counter-increment: lst-ctn-kix_j73m0ayaholw-8;
+      }
+      ol.lst-kix_tczx9grtlag8-8.start {
+        counter-reset: lst-ctn-kix_tczx9grtlag8-8 0;
+      }
+      ol.lst-kix_t0bmnl9bsu28-6.start {
+        counter-reset: lst-ctn-kix_t0bmnl9bsu28-6 0;
+      }
+      ol.lst-kix_q2k6dq6ukorq-3.start {
+        counter-reset: lst-ctn-kix_q2k6dq6ukorq-3 0;
+      }
+      .lst-kix_t0bmnl9bsu28-5 > li {
+        counter-increment: lst-ctn-kix_t0bmnl9bsu28-5;
+      }
+      ul.lst-kix_i2az6cw3vb85-2 {
+        list-style-type: none;
+      }
+      .lst-kix_uklpstvt09kj-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ul.lst-kix_i2az6cw3vb85-1 {
+        list-style-type: none;
+      }
+      .lst-kix_tczx9grtlag8-1 > li:before {
+        content: "" counter(lst-ctn-kix_tczx9grtlag8-1, lower-latin) ". ";
+      }
+      ul.lst-kix_i2az6cw3vb85-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_i2az6cw3vb85-3 {
+        list-style-type: none;
+      }
+      .lst-kix_hy5l3i205ziq-4 > li {
+        counter-increment: lst-ctn-kix_hy5l3i205ziq-4;
+      }
+      ul.lst-kix_i2az6cw3vb85-0 {
+        list-style-type: none;
+      }
+      .lst-kix_ciyq8h2db8dp-2 > li {
+        counter-increment: lst-ctn-kix_ciyq8h2db8dp-2;
+      }
+      ol.lst-kix_8uyd1khpfw5h-5.start {
+        counter-reset: lst-ctn-kix_8uyd1khpfw5h-5 0;
+      }
+      .lst-kix_i2az6cw3vb85-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ul.lst-kix_i2az6cw3vb85-6 {
+        list-style-type: none;
+      }
+      .lst-kix_uklpstvt09kj-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_q2k6dq6ukorq-0.start {
+        counter-reset: lst-ctn-kix_q2k6dq6ukorq-0 0;
+      }
+      ul.lst-kix_i2az6cw3vb85-5 {
+        list-style-type: none;
+      }
+      .lst-kix_tczx9grtlag8-3 > li:before {
+        content: "" counter(lst-ctn-kix_tczx9grtlag8-3, decimal) ". ";
+      }
+      ul.lst-kix_i2az6cw3vb85-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_i2az6cw3vb85-7 {
+        list-style-type: none;
+      }
+      .lst-kix_tczx9grtlag8-4 > li {
+        counter-increment: lst-ctn-kix_tczx9grtlag8-4;
+      }
+      ol.lst-kix_t0bmnl9bsu28-7.start {
+        counter-reset: lst-ctn-kix_t0bmnl9bsu28-7 0;
+      }
+      ol.lst-kix_j73m0ayaholw-2.start {
+        counter-reset: lst-ctn-kix_j73m0ayaholw-2 0;
+      }
+      .lst-kix_fmh85vykfuhc-8 > li {
+        counter-increment: lst-ctn-kix_fmh85vykfuhc-8;
+      }
+      .lst-kix_uklpstvt09kj-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_hy5l3i205ziq-3 > li {
+        counter-increment: lst-ctn-kix_hy5l3i205ziq-3;
+      }
+      .lst-kix_uklpstvt09kj-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_8uyd1khpfw5h-8 > li {
+        counter-increment: lst-ctn-kix_8uyd1khpfw5h-8;
+      }
+      .lst-kix_q2k6dq6ukorq-4 > li {
+        counter-increment: lst-ctn-kix_q2k6dq6ukorq-4;
+      }
+      .lst-kix_tczx9grtlag8-2 > li {
+        counter-increment: lst-ctn-kix_tczx9grtlag8-2;
+      }
+      .lst-kix_ta53u5oxw56f-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_ta53u5oxw56f-2 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_hy5l3i205ziq-2.start {
+        counter-reset: lst-ctn-kix_hy5l3i205ziq-2 0;
+      }
+      ol.lst-kix_tczx9grtlag8-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_hy5l3i205ziq-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_tczx9grtlag8-3.start {
+        counter-reset: lst-ctn-kix_tczx9grtlag8-3 0;
+      }
+      ol.lst-kix_tczx9grtlag8-6 {
+        list-style-type: none;
+      }
+      ol.lst-kix_fmh85vykfuhc-1.start {
+        counter-reset: lst-ctn-kix_fmh85vykfuhc-1 0;
+      }
+      ol.lst-kix_hy5l3i205ziq-7 {
+        list-style-type: none;
+      }
+      ol.lst-kix_tczx9grtlag8-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_hy5l3i205ziq-6 {
+        list-style-type: none;
+      }
+      ol.lst-kix_tczx9grtlag8-4 {
+        list-style-type: none;
+      }
+      .lst-kix_t0bmnl9bsu28-4 > li {
+        counter-increment: lst-ctn-kix_t0bmnl9bsu28-4;
+      }
+      .lst-kix_hy5l3i205ziq-5 > li {
+        counter-increment: lst-ctn-kix_hy5l3i205ziq-5;
+      }
+      ol.lst-kix_tczx9grtlag8-8 {
+        list-style-type: none;
+      }
+      ol.lst-kix_hy5l3i205ziq-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8uyd1khpfw5h-8.start {
+        counter-reset: lst-ctn-kix_8uyd1khpfw5h-8 0;
+      }
+      ol.lst-kix_hy5l3i205ziq-0 {
+        list-style-type: none;
+      }
+      .lst-kix_tczx9grtlag8-5 > li:before {
+        content: "" counter(lst-ctn-kix_tczx9grtlag8-5, lower-roman) ". ";
+      }
+      ol.lst-kix_j73m0ayaholw-0.start {
+        counter-reset: lst-ctn-kix_j73m0ayaholw-0 0;
+      }
+      .lst-kix_uklpstvt09kj-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_hy5l3i205ziq-5 {
+        list-style-type: none;
+      }
+      ol.lst-kix_hy5l3i205ziq-4 {
+        list-style-type: none;
+      }
+      .lst-kix_tczx9grtlag8-7 > li:before {
+        content: "" counter(lst-ctn-kix_tczx9grtlag8-7, lower-latin) ". ";
+      }
+      ol.lst-kix_hy5l3i205ziq-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_hy5l3i205ziq-2 {
+        list-style-type: none;
+      }
+      .lst-kix_t0bmnl9bsu28-0 > li:before {
+        content: "" counter(lst-ctn-kix_t0bmnl9bsu28-0, decimal) ". ";
+      }
+      .lst-kix_t0bmnl9bsu28-2 > li:before {
+        content: "" counter(lst-ctn-kix_t0bmnl9bsu28-2, lower-roman) ". ";
+      }
+      ol.lst-kix_tczx9grtlag8-6.start {
+        counter-reset: lst-ctn-kix_tczx9grtlag8-6 0;
+      }
+      ol.lst-kix_fmh85vykfuhc-0.start {
+        counter-reset: lst-ctn-kix_fmh85vykfuhc-0 0;
+      }
+      ol.lst-kix_hy5l3i205ziq-0.start {
+        counter-reset: lst-ctn-kix_hy5l3i205ziq-0 0;
+      }
+      .lst-kix_pn1pf2xro67f-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_8uyd1khpfw5h-7.start {
+        counter-reset: lst-ctn-kix_8uyd1khpfw5h-7 0;
+      }
+      .lst-kix_ta53u5oxw56f-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_t0bmnl9bsu28-8 > li:before {
+        content: "" counter(lst-ctn-kix_t0bmnl9bsu28-8, lower-roman) ". ";
+      }
+      .lst-kix_pn1pf2xro67f-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_ta53u5oxw56f-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_ta53u5oxw56f-8 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_pn1pf2xro67f-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_t0bmnl9bsu28-4 > li:before {
+        content: "" counter(lst-ctn-kix_t0bmnl9bsu28-4, lower-latin) ". ";
+      }
+      .lst-kix_t0bmnl9bsu28-6 > li:before {
+        content: "" counter(lst-ctn-kix_t0bmnl9bsu28-6, decimal) ". ";
+      }
+      .lst-kix_j73m0ayaholw-3 > li {
+        counter-increment: lst-ctn-kix_j73m0ayaholw-3;
+      }
+      .lst-kix_ciyq8h2db8dp-8 > li:before {
+        content: "" counter(lst-ctn-kix_ciyq8h2db8dp-8, lower-roman) ". ";
+      }
+      .lst-kix_fmh85vykfuhc-3 > li {
+        counter-increment: lst-ctn-kix_fmh85vykfuhc-3;
+      }
+      ul.lst-kix_pn1pf2xro67f-5 {
+        list-style-type: none;
+      }
+      .lst-kix_i2az6cw3vb85-0 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_ciyq8h2db8dp-1 > li {
+        counter-increment: lst-ctn-kix_ciyq8h2db8dp-1;
+      }
+      ul.lst-kix_pn1pf2xro67f-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_pn1pf2xro67f-7 {
+        list-style-type: none;
+      }
+      ul.lst-kix_pn1pf2xro67f-6 {
+        list-style-type: none;
+      }
+      ol.lst-kix_8uyd1khpfw5h-6.start {
+        counter-reset: lst-ctn-kix_8uyd1khpfw5h-6 0;
+      }
+      ol.lst-kix_j73m0ayaholw-1.start {
+        counter-reset: lst-ctn-kix_j73m0ayaholw-1 0;
+      }
+      .lst-kix_ciyq8h2db8dp-6 > li:before {
+        content: "" counter(lst-ctn-kix_ciyq8h2db8dp-6, decimal) ". ";
+      }
+      .lst-kix_ciyq8h2db8dp-7 > li {
+        counter-increment: lst-ctn-kix_ciyq8h2db8dp-7;
+      }
+      ul.lst-kix_pn1pf2xro67f-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_pn1pf2xro67f-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_pn1pf2xro67f-3 {
+        list-style-type: none;
+      }
+      ul.lst-kix_pn1pf2xro67f-2 {
+        list-style-type: none;
+      }
+      .lst-kix_ciyq8h2db8dp-0 > li:before {
+        content: "" counter(lst-ctn-kix_ciyq8h2db8dp-0, decimal) ". ";
+      }
+      .lst-kix_i2az6cw3vb85-4 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_pn1pf2xro67f-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_i2az6cw3vb85-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_i2az6cw3vb85-6 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_q2k6dq6ukorq-5 > li {
+        counter-increment: lst-ctn-kix_q2k6dq6ukorq-5;
+      }
+      .lst-kix_hy5l3i205ziq-8 > li:before {
+        content: "" counter(lst-ctn-kix_hy5l3i205ziq-0, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-1, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-2, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-3, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-4, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-5, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-6, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-7, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-8, decimal) ". ";
+      }
+      .lst-kix_ciyq8h2db8dp-4 > li:before {
+        content: "" counter(lst-ctn-kix_ciyq8h2db8dp-4, lower-latin) ". ";
+      }
+      ol.lst-kix_tczx9grtlag8-5.start {
+        counter-reset: lst-ctn-kix_tczx9grtlag8-5 0;
+      }
+      .lst-kix_ciyq8h2db8dp-2 > li:before {
+        content: "" counter(lst-ctn-kix_ciyq8h2db8dp-2, lower-roman) ". ";
+      }
+      .lst-kix_8uyd1khpfw5h-3 > li {
+        counter-increment: lst-ctn-kix_8uyd1khpfw5h-3;
+      }
+      .lst-kix_tczx9grtlag8-3 > li {
+        counter-increment: lst-ctn-kix_tczx9grtlag8-3;
+      }
+      .lst-kix_q2k6dq6ukorq-1 > li:before {
+        content: "(" counter(lst-ctn-kix_q2k6dq6ukorq-1, lower-roman) ") ";
+      }
+      .lst-kix_q2k6dq6ukorq-0 > li:before {
+        content: "(" counter(lst-ctn-kix_q2k6dq6ukorq-0, lower-latin) ") ";
+      }
+      .lst-kix_8uyd1khpfw5h-4 > li:before {
+        content: "" counter(lst-ctn-kix_8uyd1khpfw5h-4, lower-latin) ". ";
+      }
+      .lst-kix_8uyd1khpfw5h-6 > li:before {
+        content: "" counter(lst-ctn-kix_8uyd1khpfw5h-6, decimal) ". ";
+      }
+      ol.lst-kix_t0bmnl9bsu28-3.start {
+        counter-reset: lst-ctn-kix_t0bmnl9bsu28-3 0;
+      }
+      .lst-kix_8uyd1khpfw5h-5 > li:before {
+        content: "" counter(lst-ctn-kix_8uyd1khpfw5h-5, lower-roman) ". ";
+      }
+      ol.lst-kix_ciyq8h2db8dp-2.start {
+        counter-reset: lst-ctn-kix_ciyq8h2db8dp-2 0;
+      }
+      .lst-kix_8uyd1khpfw5h-1 > li:before {
+        content: "" counter(lst-ctn-kix_8uyd1khpfw5h-1, lower-latin) ". ";
+      }
+      .lst-kix_q2k6dq6ukorq-5 > li:before {
+        content: "" counter(lst-ctn-kix_q2k6dq6ukorq-5, decimal) ") ";
+      }
+      .lst-kix_8uyd1khpfw5h-0 > li:before {
+        content: "" counter(lst-ctn-kix_8uyd1khpfw5h-0, decimal) ". ";
+      }
+      .lst-kix_8uyd1khpfw5h-8 > li:before {
+        content: "" counter(lst-ctn-kix_8uyd1khpfw5h-8, lower-roman) ". ";
+      }
+      .lst-kix_fmh85vykfuhc-2 > li {
+        counter-increment: lst-ctn-kix_fmh85vykfuhc-2;
+      }
+      .lst-kix_q2k6dq6ukorq-6 > li:before {
+        content: "" counter(lst-ctn-kix_q2k6dq6ukorq-6, lower-latin) ". ";
+      }
+      .lst-kix_q2k6dq6ukorq-7 > li:before {
+        content: "" counter(lst-ctn-kix_q2k6dq6ukorq-7, lower-roman) ". ";
+      }
+      ol.lst-kix_fmh85vykfuhc-5.start {
+        counter-reset: lst-ctn-kix_fmh85vykfuhc-5 0;
+      }
+      .lst-kix_hy5l3i205ziq-6 > li:before {
+        content: "" counter(lst-ctn-kix_hy5l3i205ziq-0, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-1, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-2, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-3, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-4, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-5, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-6, decimal) ". ";
+      }
+      .lst-kix_8uyd1khpfw5h-7 > li:before {
+        content: "" counter(lst-ctn-kix_8uyd1khpfw5h-7, lower-latin) ". ";
+      }
+      .lst-kix_hy5l3i205ziq-5 > li:before {
+        content: "" counter(lst-ctn-kix_hy5l3i205ziq-0, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-1, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-2, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-3, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-4, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-5, decimal) ". ";
+      }
+      ol.lst-kix_8uyd1khpfw5h-1.start {
+        counter-reset: lst-ctn-kix_8uyd1khpfw5h-1 0;
+      }
+      .lst-kix_hy5l3i205ziq-3 > li:before {
+        content: "" counter(lst-ctn-kix_hy5l3i205ziq-0, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-1, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-2, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-3, decimal) ". ";
+      }
+      ol.lst-kix_hy5l3i205ziq-1.start {
+        counter-reset: lst-ctn-kix_hy5l3i205ziq-1 0;
+      }
+      ul.lst-kix_pn1pf2xro67f-8 {
+        list-style-type: none;
+      }
+      .lst-kix_hy5l3i205ziq-4 > li:before {
+        content: "" counter(lst-ctn-kix_hy5l3i205ziq-0, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-1, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-2, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-3, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-4, decimal) ". ";
+      }
+      .lst-kix_hy5l3i205ziq-1 > li:before {
+        content: "" counter(lst-ctn-kix_hy5l3i205ziq-0, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-1, decimal) ". ";
+      }
+      .lst-kix_q2k6dq6ukorq-4 > li:before {
+        content: "" counter(lst-ctn-kix_q2k6dq6ukorq-4, lower-roman) ") ";
+      }
+      .lst-kix_tczx9grtlag8-8 > li {
+        counter-increment: lst-ctn-kix_tczx9grtlag8-8;
+      }
+      ol.lst-kix_tczx9grtlag8-4.start {
+        counter-reset: lst-ctn-kix_tczx9grtlag8-4 0;
+      }
+      .lst-kix_q2k6dq6ukorq-2 > li:before {
+        content: "(" counter(lst-ctn-kix_q2k6dq6ukorq-2, decimal) ") ";
+      }
+      .lst-kix_q2k6dq6ukorq-3 > li:before {
+        content: "" counter(lst-ctn-kix_q2k6dq6ukorq-3, lower-latin) ") ";
+      }
+      .lst-kix_hy5l3i205ziq-2 > li:before {
+        content: "" counter(lst-ctn-kix_hy5l3i205ziq-0, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-1, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-2, decimal) ". ";
+      }
+      ol.lst-kix_q2k6dq6ukorq-7.start {
+        counter-reset: lst-ctn-kix_q2k6dq6ukorq-7 0;
+      }
+      .lst-kix_8uyd1khpfw5h-1 > li {
+        counter-increment: lst-ctn-kix_8uyd1khpfw5h-1;
+      }
+      .lst-kix_fmh85vykfuhc-0 > li:before {
+        content: "" counter(lst-ctn-kix_fmh85vykfuhc-0, decimal) ". ";
+      }
+      ol.lst-kix_q2k6dq6ukorq-1.start {
+        counter-reset: lst-ctn-kix_q2k6dq6ukorq-1 0;
+      }
+      .lst-kix_hy5l3i205ziq-0 > li:before {
+        content: "" counter(lst-ctn-kix_hy5l3i205ziq-0, decimal) ". ";
+      }
+      .lst-kix_hy5l3i205ziq-0 > li {
+        counter-increment: lst-ctn-kix_hy5l3i205ziq-0;
+      }
+      .lst-kix_t0bmnl9bsu28-1 > li {
+        counter-increment: lst-ctn-kix_t0bmnl9bsu28-1;
+      }
+      .lst-kix_fmh85vykfuhc-3 > li:before {
+        content: "" counter(lst-ctn-kix_fmh85vykfuhc-0, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-1, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-2, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-3, decimal) ". ";
+      }
+      .lst-kix_fmh85vykfuhc-1 > li:before {
+        content: "" counter(lst-ctn-kix_fmh85vykfuhc-0, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-1, decimal) ". ";
+      }
+      .lst-kix_fmh85vykfuhc-2 > li:before {
+        content: "" counter(lst-ctn-kix_fmh85vykfuhc-0, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-1, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-2, decimal) ". ";
+      }
+      ol.lst-kix_j73m0ayaholw-6.start {
+        counter-reset: lst-ctn-kix_j73m0ayaholw-6 0;
+      }
+      .lst-kix_q2k6dq6ukorq-7 > li {
+        counter-increment: lst-ctn-kix_q2k6dq6ukorq-7;
+      }
+      .lst-kix_fmh85vykfuhc-7 > li:before {
+        content: "" counter(lst-ctn-kix_fmh85vykfuhc-0, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-1, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-2, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-3, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-4, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-5, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-6, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-7, decimal) ". ";
+      }
+      .lst-kix_j73m0ayaholw-7 > li {
+        counter-increment: lst-ctn-kix_j73m0ayaholw-7;
+      }
+      .lst-kix_fmh85vykfuhc-8 > li:before {
+        content: "" counter(lst-ctn-kix_fmh85vykfuhc-0, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-1, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-2, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-3, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-4, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-5, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-6, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-7, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-8, decimal) ". ";
+      }
+      ol.lst-kix_t0bmnl9bsu28-8.start {
+        counter-reset: lst-ctn-kix_t0bmnl9bsu28-8 0;
+      }
+      .lst-kix_fmh85vykfuhc-4 > li:before {
+        content: "" counter(lst-ctn-kix_fmh85vykfuhc-0, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-1, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-2, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-3, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-4, decimal) ". ";
+      }
+      .lst-kix_fmh85vykfuhc-5 > li:before {
+        content: "" counter(lst-ctn-kix_fmh85vykfuhc-0, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-1, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-2, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-3, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-4, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-5, decimal) ". ";
+      }
+      .lst-kix_fmh85vykfuhc-6 > li:before {
+        content: "" counter(lst-ctn-kix_fmh85vykfuhc-0, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-1, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-2, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-3, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-4, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-5, decimal) "."
+          counter(lst-ctn-kix_fmh85vykfuhc-6, decimal) ". ";
+      }
+      .lst-kix_ciyq8h2db8dp-8 > li {
+        counter-increment: lst-ctn-kix_ciyq8h2db8dp-8;
+      }
+      ol.lst-kix_ciyq8h2db8dp-7.start {
+        counter-reset: lst-ctn-kix_ciyq8h2db8dp-7 0;
+      }
+      ol.lst-kix_tczx9grtlag8-3 {
+        list-style-type: none;
+      }
+      ol.lst-kix_tczx9grtlag8-2 {
+        list-style-type: none;
+      }
+      ol.lst-kix_tczx9grtlag8-1 {
+        list-style-type: none;
+      }
+      ol.lst-kix_tczx9grtlag8-0 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ta53u5oxw56f-8 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ta53u5oxw56f-7 {
+        list-style-type: none;
+      }
+      .lst-kix_ciyq8h2db8dp-6 > li {
+        counter-increment: lst-ctn-kix_ciyq8h2db8dp-6;
+      }
+      .lst-kix_tczx9grtlag8-1 > li {
+        counter-increment: lst-ctn-kix_tczx9grtlag8-1;
+      }
+      .lst-kix_8uyd1khpfw5h-5 > li {
+        counter-increment: lst-ctn-kix_8uyd1khpfw5h-5;
+      }
+      ul.lst-kix_ta53u5oxw56f-2 {
+        list-style-type: none;
+      }
+      .lst-kix_fmh85vykfuhc-4 > li {
+        counter-increment: lst-ctn-kix_fmh85vykfuhc-4;
+      }
+      .lst-kix_q2k6dq6ukorq-0 > li {
+        counter-increment: lst-ctn-kix_q2k6dq6ukorq-0;
+      }
+      ul.lst-kix_ta53u5oxw56f-1 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ta53u5oxw56f-0 {
+        list-style-type: none;
+      }
+      ol.lst-kix_q2k6dq6ukorq-2.start {
+        counter-reset: lst-ctn-kix_q2k6dq6ukorq-2 0;
+      }
+      ul.lst-kix_ta53u5oxw56f-6 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ta53u5oxw56f-5 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ta53u5oxw56f-4 {
+        list-style-type: none;
+      }
+      ul.lst-kix_ta53u5oxw56f-3 {
+        list-style-type: none;
+      }
+      .lst-kix_j73m0ayaholw-5 > li {
+        counter-increment: lst-ctn-kix_j73m0ayaholw-5;
+      }
+      ol.lst-kix_ciyq8h2db8dp-8.start {
+        counter-reset: lst-ctn-kix_ciyq8h2db8dp-8 0;
+      }
+      .lst-kix_t0bmnl9bsu28-6 > li {
+        counter-increment: lst-ctn-kix_t0bmnl9bsu28-6;
+      }
+      .lst-kix_t0bmnl9bsu28-3 > li {
+        counter-increment: lst-ctn-kix_t0bmnl9bsu28-3;
+      }
+      .lst-kix_8uyd1khpfw5h-2 > li:before {
+        content: "" counter(lst-ctn-kix_8uyd1khpfw5h-2, lower-roman) ". ";
+      }
+      .lst-kix_8uyd1khpfw5h-3 > li:before {
+        content: "" counter(lst-ctn-kix_8uyd1khpfw5h-3, decimal) ". ";
+      }
+      ol.lst-kix_ciyq8h2db8dp-1.start {
+        counter-reset: lst-ctn-kix_ciyq8h2db8dp-1 0;
+      }
+      ol.lst-kix_hy5l3i205ziq-5.start {
+        counter-reset: lst-ctn-kix_hy5l3i205ziq-5 0;
+      }
+      ol.lst-kix_j73m0ayaholw-5.start {
+        counter-reset: lst-ctn-kix_j73m0ayaholw-5 0;
+      }
+      .lst-kix_tczx9grtlag8-0 > li:before {
+        content: "" counter(lst-ctn-kix_tczx9grtlag8-0, decimal) ". ";
+      }
+      .lst-kix_uklpstvt09kj-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_uklpstvt09kj-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_fmh85vykfuhc-7 > li {
+        counter-increment: lst-ctn-kix_fmh85vykfuhc-7;
+      }
+      .lst-kix_i2az6cw3vb85-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_tczx9grtlag8-4 > li:before {
+        content: "" counter(lst-ctn-kix_tczx9grtlag8-4, lower-latin) ". ";
+      }
+      .lst-kix_q2k6dq6ukorq-2 > li {
+        counter-increment: lst-ctn-kix_q2k6dq6ukorq-2;
+      }
+      .lst-kix_tczx9grtlag8-2 > li:before {
+        content: "" counter(lst-ctn-kix_tczx9grtlag8-2, lower-roman) ". ";
+      }
+      .lst-kix_uklpstvt09kj-5 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_hy5l3i205ziq-8.start {
+        counter-reset: lst-ctn-kix_hy5l3i205ziq-8 0;
+      }
+      .lst-kix_j73m0ayaholw-0 > li {
+        counter-increment: lst-ctn-kix_j73m0ayaholw-0;
+      }
+      .lst-kix_ciyq8h2db8dp-3 > li {
+        counter-increment: lst-ctn-kix_ciyq8h2db8dp-3;
+      }
+      .lst-kix_q2k6dq6ukorq-3 > li {
+        counter-increment: lst-ctn-kix_q2k6dq6ukorq-3;
+      }
+      .lst-kix_uklpstvt09kj-1 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_t0bmnl9bsu28-4.start {
+        counter-reset: lst-ctn-kix_t0bmnl9bsu28-4 0;
+      }
+      .lst-kix_tczx9grtlag8-5 > li {
+        counter-increment: lst-ctn-kix_tczx9grtlag8-5;
+      }
+      .lst-kix_q2k6dq6ukorq-1 > li {
+        counter-increment: lst-ctn-kix_q2k6dq6ukorq-1;
+      }
+      ol.lst-kix_q2k6dq6ukorq-8.start {
+        counter-reset: lst-ctn-kix_q2k6dq6ukorq-8 0;
+      }
+      ol.lst-kix_fmh85vykfuhc-4.start {
+        counter-reset: lst-ctn-kix_fmh85vykfuhc-4 0;
+      }
+      ol.lst-kix_8uyd1khpfw5h-2.start {
+        counter-reset: lst-ctn-kix_8uyd1khpfw5h-2 0;
+      }
+      .lst-kix_ta53u5oxw56f-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_8uyd1khpfw5h-7 > li {
+        counter-increment: lst-ctn-kix_8uyd1khpfw5h-7;
+      }
+      ol.lst-kix_ciyq8h2db8dp-3.start {
+        counter-reset: lst-ctn-kix_ciyq8h2db8dp-3 0;
+      }
+      .lst-kix_hy5l3i205ziq-2 > li {
+        counter-increment: lst-ctn-kix_hy5l3i205ziq-2;
+      }
+      .lst-kix_tczx9grtlag8-8 > li:before {
+        content: "" counter(lst-ctn-kix_tczx9grtlag8-8, lower-roman) ". ";
+      }
+      .lst-kix_j73m0ayaholw-1 > li {
+        counter-increment: lst-ctn-kix_j73m0ayaholw-1;
+      }
+      .lst-kix_t0bmnl9bsu28-7 > li {
+        counter-increment: lst-ctn-kix_t0bmnl9bsu28-7;
+      }
+      ol.lst-kix_t0bmnl9bsu28-1.start {
+        counter-reset: lst-ctn-kix_t0bmnl9bsu28-1 0;
+      }
+      ol.lst-kix_ciyq8h2db8dp-6.start {
+        counter-reset: lst-ctn-kix_ciyq8h2db8dp-6 0;
+      }
+      .lst-kix_tczx9grtlag8-6 > li:before {
+        content: "" counter(lst-ctn-kix_tczx9grtlag8-6, decimal) ". ";
+      }
+      ol.lst-kix_tczx9grtlag8-0.start {
+        counter-reset: lst-ctn-kix_tczx9grtlag8-0 0;
+      }
+      .lst-kix_t0bmnl9bsu28-1 > li:before {
+        content: "" counter(lst-ctn-kix_t0bmnl9bsu28-1, lower-latin) ". ";
+      }
+      .lst-kix_t0bmnl9bsu28-2 > li {
+        counter-increment: lst-ctn-kix_t0bmnl9bsu28-2;
+      }
+      .lst-kix_hy5l3i205ziq-7 > li {
+        counter-increment: lst-ctn-kix_hy5l3i205ziq-7;
+      }
+      .lst-kix_t0bmnl9bsu28-3 > li:before {
+        content: "" counter(lst-ctn-kix_t0bmnl9bsu28-3, decimal) ". ";
+      }
+      .lst-kix_hy5l3i205ziq-1 > li {
+        counter-increment: lst-ctn-kix_hy5l3i205ziq-1;
+      }
+      .lst-kix_t0bmnl9bsu28-8 > li {
+        counter-increment: lst-ctn-kix_t0bmnl9bsu28-8;
+      }
+      .lst-kix_pn1pf2xro67f-0 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_q2k6dq6ukorq-5.start {
+        counter-reset: lst-ctn-kix_q2k6dq6ukorq-5 0;
+      }
+      .lst-kix_ta53u5oxw56f-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_t0bmnl9bsu28-7 > li:before {
+        content: "" counter(lst-ctn-kix_t0bmnl9bsu28-7, lower-latin) ". ";
+      }
+      .lst-kix_ta53u5oxw56f-3 > li:before {
+        content: "\0025cf   ";
+      }
+      .lst-kix_ta53u5oxw56f-7 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_pn1pf2xro67f-4 > li:before {
+        content: "\0025cb   ";
+      }
+      ol.lst-kix_j73m0ayaholw-7.start {
+        counter-reset: lst-ctn-kix_j73m0ayaholw-7 0;
+      }
+      .lst-kix_t0bmnl9bsu28-5 > li:before {
+        content: "" counter(lst-ctn-kix_t0bmnl9bsu28-5, lower-roman) ". ";
+      }
+      ol.lst-kix_t0bmnl9bsu28-2.start {
+        counter-reset: lst-ctn-kix_t0bmnl9bsu28-2 0;
+      }
+      ol.lst-kix_fmh85vykfuhc-7.start {
+        counter-reset: lst-ctn-kix_fmh85vykfuhc-7 0;
+      }
+      ol.lst-kix_hy5l3i205ziq-6.start {
+        counter-reset: lst-ctn-kix_hy5l3i205ziq-6 0;
+      }
+      .lst-kix_pn1pf2xro67f-2 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_fmh85vykfuhc-0 > li {
+        counter-increment: lst-ctn-kix_fmh85vykfuhc-0;
+      }
+      ol.lst-kix_q2k6dq6ukorq-6.start {
+        counter-reset: lst-ctn-kix_q2k6dq6ukorq-6 0;
+      }
+      .lst-kix_ciyq8h2db8dp-5 > li:before {
+        content: "" counter(lst-ctn-kix_ciyq8h2db8dp-5, lower-roman) ". ";
+      }
+      ol.lst-kix_fmh85vykfuhc-6.start {
+        counter-reset: lst-ctn-kix_fmh85vykfuhc-6 0;
+      }
+      li.li-bullet-0:before {
+        margin-left: -18pt;
+        white-space: nowrap;
+        display: inline-block;
+        min-width: 18pt;
+      }
+      .lst-kix_ciyq8h2db8dp-4 > li {
+        counter-increment: lst-ctn-kix_ciyq8h2db8dp-4;
+      }
+      .lst-kix_ciyq8h2db8dp-7 > li:before {
+        content: "" counter(lst-ctn-kix_ciyq8h2db8dp-7, lower-latin) ". ";
+      }
+      .lst-kix_pn1pf2xro67f-6 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_j73m0ayaholw-8.start {
+        counter-reset: lst-ctn-kix_j73m0ayaholw-8 0;
+      }
+      .lst-kix_q2k6dq6ukorq-8 > li:before {
+        content: "" counter(lst-ctn-kix_q2k6dq6ukorq-8, decimal) ". ";
+      }
+      .lst-kix_i2az6cw3vb85-3 > li:before {
+        content: "\0025cf   ";
+      }
+      ol.lst-kix_ciyq8h2db8dp-4.start {
+        counter-reset: lst-ctn-kix_ciyq8h2db8dp-4 0;
+      }
+      ol.lst-kix_8uyd1khpfw5h-0.start {
+        counter-reset: lst-ctn-kix_8uyd1khpfw5h-0 0;
+      }
+      .lst-kix_hy5l3i205ziq-7 > li:before {
+        content: "" counter(lst-ctn-kix_hy5l3i205ziq-0, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-1, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-2, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-3, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-4, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-5, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-6, decimal) "."
+          counter(lst-ctn-kix_hy5l3i205ziq-7, decimal) ". ";
+      }
+      .lst-kix_i2az6cw3vb85-1 > li:before {
+        content: "\0025cb   ";
+      }
+      .lst-kix_i2az6cw3vb85-5 > li:before {
+        content: "\0025a0   ";
+      }
+      .lst-kix_8uyd1khpfw5h-6 > li {
+        counter-increment: lst-ctn-kix_8uyd1khpfw5h-6;
+      }
+      .lst-kix_ciyq8h2db8dp-1 > li:before {
+        content: "" counter(lst-ctn-kix_ciyq8h2db8dp-1, lower-latin) ". ";
+      }
+      .lst-kix_pn1pf2xro67f-8 > li:before {
+        content: "\0025a0   ";
+      }
+      ol.lst-kix_hy5l3i205ziq-7.start {
+        counter-reset: lst-ctn-kix_hy5l3i205ziq-7 0;
+      }
+      .lst-kix_tczx9grtlag8-6 > li {
+        counter-increment: lst-ctn-kix_tczx9grtlag8-6;
+      }
+      .lst-kix_q2k6dq6ukorq-8 > li {
+        counter-increment: lst-ctn-kix_q2k6dq6ukorq-8;
+      }
+      .lst-kix_tczx9grtlag8-0 > li {
+        counter-increment: lst-ctn-kix_tczx9grtlag8-0;
+      }
+      .lst-kix_8uyd1khpfw5h-0 > li {
+        counter-increment: lst-ctn-kix_8uyd1khpfw5h-0;
+      }
+      .lst-kix_fmh85vykfuhc-6 > li {
+        counter-increment: lst-ctn-kix_fmh85vykfuhc-6;
+      }
+      .lst-kix_ciyq8h2db8dp-3 > li:before {
+        content: "" counter(lst-ctn-kix_ciyq8h2db8dp-3, decimal) ". ";
+      }
+      ol {
+        margin: 0;
+        padding: 0;
+      }
+      table td,
+      table th {
+        padding: 0;
+      }
+      .c8 {
+        margin-left: 72pt;
+        padding-top: 10pt;
+        padding-left: 0pt;
+        padding-bottom: 10pt;
+        line-height: 1.5;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+      }
+      .c5 {
+        color: #000000;
+        font-weight: 700;
+        text-decoration: none;
+        vertical-align: baseline;
+        font-size: 11pt;
+        font-family: "Arial";
+        font-style: normal;
+      }
+      .c0 {
+        color: #000000;
+        font-weight: 400;
+        text-decoration: none;
+        vertical-align: baseline;
+        font-size: 11pt;
+        font-family: "Arial";
+        font-style: normal;
+      }
+      .c11 {
+        padding-top: 10pt;
+        padding-bottom: 10pt;
+        line-height: 1.5;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+        height: 11pt;
+      }
+      .c19 {
+        padding-top: 12pt;
+        padding-bottom: 12pt;
+        line-height: 1.5;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+      }
+      .c16 {
+        padding-top: 10pt;
+        padding-bottom: 10pt;
+        line-height: 1.5;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+      }
+      .c4 {
+        padding-top: 10pt;
+        padding-bottom: 10pt;
+        line-height: 1.5;
+        orphans: 2;
+        widows: 2;
+        text-align: justify;
+      }
+      .c13 {
+        color: #000000;
+        vertical-align: baseline;
+        font-size: 11pt;
+        font-family: "Arial";
+        font-style: normal;
+      }
+      .c3 {
+        text-decoration-skip-ink: none;
+        -webkit-text-decoration-skip: none;
+        color: #1155cc;
+        text-decoration: underline;
+      }
+      .c17 {
+        background-color: #ffffff;
+        max-width: 564pt;
+        padding: 24pt 24pt 24pt 24pt;
+      }
+      .c9 {
+        text-decoration-skip-ink: none;
+        -webkit-text-decoration-skip: none;
+        text-decoration: underline;
+      }
+      .c6 {
+        margin-left: 36pt;
+        padding-left: 0pt;
+      }
+      .c2 {
+        padding: 0;
+        margin: 0;
+      }
+      .c10 {
+        margin-left: 72pt;
+        padding-left: 0pt;
+      }
+      .c15 {
+        background-color: #f8f8f8;
+        color: #1d1c1d;
+      }
+      .c1 {
+        color: inherit;
+        text-decoration: inherit;
+      }
+      .c14 {
+        background-color: #ffff00;
+      }
+      .c7 {
+        page-break-after: avoid;
+      }
+      .c18 {
+        font-weight: 400;
+      }
+      .c12 {
+        font-weight: 700;
+      }
+      .title {
+        padding-top: 0pt;
+        color: #000000;
+        font-size: 26pt;
+        padding-bottom: 3pt;
+        font-family: "Arial";
+        line-height: 1.15;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+      }
+      .subtitle {
+        padding-top: 0pt;
+        color: #666666;
+        font-size: 15pt;
+        padding-bottom: 16pt;
+        font-family: "Arial";
+        line-height: 1.15;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+      }
+      li {
+        color: #000000;
+        font-size: 11pt;
+        font-family: "Arial";
+      }
+      p {
+        margin: 0;
+        color: #000000;
+        font-size: 11pt;
+        font-family: "Arial";
+      }
+      h1 {
+        padding-top: 20pt;
+        color: #000000;
+        font-weight: 700;
+        font-size: 11pt;
+        padding-bottom: 6pt;
+        font-family: "Arial";
+        line-height: 1.15;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+      }
+      h2 {
+        padding-top: 18pt;
+        color: #000000;
+        font-size: 11pt;
+        padding-bottom: 6pt;
+        font-family: "Arial";
+        line-height: 1.15;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+      }
+      h3 {
+        padding-top: 16pt;
+        color: #434343;
+        font-size: 14pt;
+        padding-bottom: 4pt;
+        font-family: "Arial";
+        line-height: 1.15;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+      }
+      h4 {
+        padding-top: 14pt;
+        color: #666666;
+        font-size: 12pt;
+        padding-bottom: 4pt;
+        font-family: "Arial";
+        line-height: 1.15;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+      }
+      h5 {
+        padding-top: 12pt;
+        color: #666666;
+        font-size: 11pt;
+        padding-bottom: 4pt;
+        font-family: "Arial";
+        line-height: 1.15;
+        page-break-after: avoid;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+      }
+      h6 {
+        padding-top: 12pt;
+        color: #666666;
+        font-size: 11pt;
+        padding-bottom: 4pt;
+        font-family: "Arial";
+        line-height: 1.15;
+        page-break-after: avoid;
+        font-style: italic;
+        orphans: 2;
+        widows: 2;
+        text-align: left;
+      }
+    </style>
+  </head>
+  <body class="c17 doc-content">
+    <p class="c4">
+      <span class="c13 c9 c12"
+        >THE INTERFACES ARE THE VISUAL REPRESENTATION OF THE NEAR INTENTS
+        PROTOCOL (AS DEFINED BELOW) THAT ALLOW YOU TO DISCOVER AND INTERACT WITH
+        IT. NEITHER THE COMPANY NOR THE INTERFACES CONTROL, OPERATE, OR MAINTAIN
+        THE NEAR INTENTS PROTOCOL OR ANY UNDERLYING BLOCKCHAIN OR SMART CONTRACT
+        INFRASTRUCTURE. NEITHER THE COMPANY NOR THE INTERFACES IS A BROKER,
+        FINANCIAL INSTITUTION, OR INTERMEDIARY AND IS IN NO WAY YOUR AGENT,
+        ADVISOR, OR CUSTODIAN. NEITHER THE COMPANY NOR THE INTERFACES CAN
+        INITIATE A TRANSFER OF ANY OF YOUR DIGITAL ASSETS OR OTHERWISE ACCESS
+        YOUR DIGITAL ASSETS. THE COMPANY HAS NO FIDUCIARY RELATIONSHIP OR
+        OBLIGATION TO YOU REGARDING ANY DECISIONS OR ACTIVITIES THAT YOU EFFECT
+        IN CONNECTION WITH YOUR USE OF THE NEAR INTENTS PROTOCOL.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c13 c9 c12"
+        >THE INTERFACE DOES NOT HOST, MAINTAIN OR PARTICIPATE IN ANY
+        TRANSACTIONS IN ANY THIRD PARTY PLATFORM ACCESSIBLE ON THE INTERFACE,
+        ARE NOT IN ANY WAY ASSOCIATED WITH OPERATORS OF ANY THIRD PARTY
+        PLATFORM, AND HAS NO CONTROL OVER THE OPERATION OF THE THIRD PARTY
+        PLATFORMS.
+      </span>
+    </p>
+    <p class="c4">
+      <span class="c13 c9 c12"
+        >THE COMPANY DOES NOT PROVIDE ANY REGULATED SERVICE OR ANY SERVICE
+        REQUIRING REGISTRATION OR A LICENSE WITH GIBRALTAR FINANCIAL SERVICES
+        COMMISSION.
+      </span>
+    </p>
+    <p class="c4">
+      <span class="c13 c9 c12"
+        >YOU ACKNOWLEDGE THAT YOU ARE SOLELY INTERACTING WITH DECENTRALIZED
+        SMART CONTRACTS AND ARE NOT ENTERING INTO ANY CONTRACTUAL OBLIGATIONS
+        WITH THE COMPANY.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c9 c12"
+        >THE COMPANY DOES NOT ENDORSE OR APPROVE AND MAKES NO WARRANTIES,
+        REPRESENTATIONS OR UNDERTAKINGS RELATING TO THE CONTENT AND SERVICES OF
+        ANY THIRD-PARTY PLATFORMS OR TO THE NEAR INTENTS PROTOCOL.</span
+      ><span class="c9 c12">&nbsp;</span>
+    </p>
+    <p class="c4">
+      <span class="c9 c12"
+        >YOUR USE OF THE INTERFACE MAY BE SUBJECT TO SUPPLEMENTAL TERMS, WHICH
+        CAN EITHER BE LISTED IN THIS TERMS OR WILL BE PRESENTED TO YOU FOR YOUR
+        ACCEPTANCE WHEN YOU USE THE SPECIFIC SUPPLEMENTAL SERVICE OR PRODUCT. IN
+        THE EVENT OF ANY CONFLICT BETWEEN THIS TERMS AND THE SUPPLEMENTAL TERMS,
+        THE SUPPLEMENTAL TERMS SHALL GOVERN AND CONTROL WITH RESPECT TO SUCH
+        SERVICE.
+      </span>
+    </p>
+    <p class="c4"><span class="c12">Terms of Service</span></p>
+    <p class="c4"><span class="c0">Dated: March 3rd, 2025</span></p>
+    <p class="c4">
+      <span>These Terms of Service (the &quot;</span
+      ><span class="c12">Agreement</span><span>&quot; or the &ldquo;</span
+      ><span class="c12">Terms</span
+      ><span
+        >&rdquo;) explain the terms and conditions by which you (&ldquo;</span
+      ><span class="c12">You</span><span>&rdquo;, &ldquo;</span
+      ><span class="c12">Yours</span><span>&rdquo; or &ldquo;</span
+      ><span class="c12">User</span
+      ><span>&rdquo;) may access and use the interfaces provided by </span
+      ><span>Aurora Labs Limited</span
+      ><span>&nbsp;(referred to herein as the &quot;</span
+      ><span class="c12">Company</span><span>&quot;, &quot;</span
+      ><span class="c12">we</span><span>&quot;, &quot;</span
+      ><span class="c12">our</span><span>&quot;, or &quot;</span
+      ><span class="c12">us</span><span>&quot;) (the &ldquo;</span
+      ><span class="c12">Interfaces</span><span>&rdquo;). The Interfaces </span
+      ><span
+        >enable Users to interact with the Protocol (as defined below) and any
+        third party platforms, not owned by the Company. </span
+      ><span
+        >The Interfaces shall include, but shall not necessarily be limited to, </span
+      ><span class="c3"
+        ><a
+          class="c1"
+          href="https://www.google.com/url?q=https://app.near-intents.org/&amp;sa=D&amp;source=editors&amp;ust=1741345309081317&amp;usg=AOvVaw1nAc6gbfxZKMRj68JF7VnD"
+          >https://app.near-intents.org/</a
+        ></span
+      ><span>&nbsp;a.k.a. </span><span>&ldquo;near-intents&rdquo; </span
+      ><span class="c3"
+        ><a
+          class="c1"
+          href="https://www.google.com/url?q=https://solswap.org/&amp;sa=D&amp;source=editors&amp;ust=1741345309081605&amp;usg=AOvVaw1hLhY5dP6fIdKpM0aWKq9_"
+          >https://solswap.org/</a
+        ></span
+      ><span>&nbsp;a.k.a. &ldquo;solswap&rdquo; </span
+      ><span class="c3"
+        ><a
+          class="c1"
+          href="https://www.google.com/url?q=https://dogecoinswap.org/&amp;sa=D&amp;source=editors&amp;ust=1741345309081770&amp;usg=AOvVaw1SmqKTdMe0SxzSGoPUbXqF"
+          >https://dogecoinswap.org/</a
+        ></span
+      ><span>&nbsp; a.k.a. &quot;Dogecoinswap&quot;, </span
+      ><span class="c3"
+        ><a
+          class="c1"
+          href="https://www.google.com/url?q=https://turboswap.org/&amp;sa=D&amp;source=editors&amp;ust=1741345309081922&amp;usg=AOvVaw3vr02ait3YtxwHRb6BsIF7"
+          >https://turboswap.org/</a
+        ></span
+      ><span>&nbsp;a.k.a. &quot;Turboswap&quot;, </span
+      ><span class="c3"
+        ><a
+          class="c1"
+          href="https://www.google.com/url?q=https://trump-swap.org/&amp;sa=D&amp;source=editors&amp;ust=1741345309082076&amp;usg=AOvVaw0VXdzUd10mMAFHXOg8sMT_"
+          >https://trump-swap.org/</a
+        ></span
+      ><span>&nbsp;a.k.a. </span
+      ><span class="c15">&quot;Trumpswap&quot;, and </span><span>the </span
+      ><span
+        >website-hosted user interfaces (and all features available via the
+        Interfaces).</span
+      ><span>&nbsp;The Interfaces provide access to the decentralized </span
+      ><span>NEAR Intents Protoco</span
+      ><span class="c0"
+        >l, which is not controlled or operated by the Company.
+      </span>
+    </p>
+    <p class="c4">
+      <span
+        >You must read this Agreement carefully as it governs Your use of the </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >. By accessing or using any of the Interfaces, You signify that You
+        have read, understand, and agree to be bound by this Agreement in its
+        entirety. If You do not agree, You are not authorized to access or use
+        any of our Interfaces and should not use our Interfaces.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >To access or use any of our Interfaces, You must be able to form a
+        legally binding contract with us. Accordingly, you represent that you
+        are at least the age of majority in your jurisdiction (e.g., 18 years
+        old in the United States) and have the full right, power, and authority
+        to enter into and comply with the terms and conditions of this Agreement
+        on behalf of yourself and any company or legal entity for which you may
+        access or use the Interfaces. If you are entering into this Agreement on
+        behalf of an entity, you represent to us that you have the legal
+        authority to bind such entity.</span
+      >
+    </p>
+    <p class="c4">
+      <span
+        >You further represent that you are not (a) the subject of economic or
+        trade sanctions administered or enforced by any governmental authority
+        or otherwise designated on any list of prohibited or restricted parties
+        (including but not limited to the list maintained by the Office of
+        Foreign Assets Control of the U.S. Department of the Treasury)
+        (collectively, a &ldquo;</span
+      ><span class="c12">Sanctioned Person</span
+      ><span
+        >&rdquo;) or (b) a resident, citizen or agent of, or organized in, and
+        do not have a registered office in, a jurisdiction or territory that is
+        the subject of comprehensive country-wide, territory-wide, or regional
+        economic sanctions by the United States (collectively, &ldquo;</span
+      ><span class="c12">Restricted Territories</span
+      ><span
+        >&rdquo;). You further represent that you do not intend to transact with
+        any Sanctioned Person or any person present in a Restricted Territory.
+        Finally, you represent that your access and use of any of our Interfaces
+        will fully comply with all applicable laws and regulations, and that you
+        will not access or use any of our Interfaces to conduct, promote, or
+        otherwise facilitate any illegal activity. If use of our Interfaces are
+        not permitted in your jurisdiction, you may not attempt to use any of
+        our Interfaces. Use of a Virtual Private Network (&ldquo;</span
+      ><span class="c12">VPN</span
+      ><span
+        >&rdquo;) or any other privacy or anonymization tools or techniques to
+        circumvent, or attempt to circumvent, </span
+      ><span>any</span
+      ><span class="c0"
+        >&nbsp;such jurisdictional restrictions is prohibited.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c12">NOTICE</span
+      ><span
+        >: This Agreement contains important information, including a binding
+        arbitration provision and a class action waiver, both of which impact
+        your rights as to how disputes are resolved. Our Interfaces are only
+        available to you &mdash; and you should only access any of our
+        Interfaces &mdash; if you agree completely wit</span
+      ><span>h these Te</span><span>rms.</span>
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >For purposes of this Agreement, the following terms have the meanings
+        set forth below:</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-0 start" start="1">
+      <li class="c4 c6 li-bullet-0">
+        <span class="c12">Definit</span><span class="c12">ions</span>
+      </li>
+    </ol>
+    <p class="c4">
+      <span>&ldquo;</span><span class="c12">Intent</span
+      ><span class="c0"
+        >&rdquo;: A user-generated declaration of a desired outcome (e.g., token
+        swap, cross-chain transfer) broadcast to the Solver Network.</span
+      >
+    </p>
+    <p class="c4">
+      <span>&ldquo;</span><span class="c12">Solver</span
+      ><span class="c0"
+        >&rdquo;: An independent entity (AI agent, market maker, or individual)
+        that computes and proposes execution paths for Intents.</span
+      >
+    </p>
+    <p class="c4">
+      <span>&ldquo;</span><span class="c12">Solver Bus API</span
+      ><span class="c0"
+        >&rdquo;: A decentralized communication layer connecting Solvers to the
+        Protocol.</span
+      >
+    </p>
+    <p class="c4">
+      <span>&quot;</span><span class="c12">Solver Network</span
+      ><span class="c0"
+        >&quot;: A decentralized network of AI-driven, algorithmic-driven or
+        human-operated Solvers that compete to fulfill user Intents by proposing
+        optimal execution plans.</span
+      >
+    </p>
+    <p class="c4">
+      <span>&ldquo;</span><span class="c12">Slippage</span
+      ><span class="c0"
+        >&quot;: The difference between the expected price of a transaction and
+        the actual price at which the transaction is executed. Slippage can
+        occur due to market volatility, low liquidity, or delays in transaction
+        processing.</span
+      >
+    </p>
+    <p class="c4">
+      <span>&ldquo;</span><span class="c12">Verifier Contract</span
+      ><span class="c0"
+        >&rdquo;: The NEAR-based smart contract that validates Intent
+        execution.</span
+      >
+    </p>
+    <p class="c4">
+      <span>&ldquo;</span><span class="c12">Omni Bridge</span
+      ><span class="c0"
+        >&rdquo;: A decentralized cross-chain bridge enabling asset transfers
+        between NEAR and other blockchains.</span
+      >
+    </p>
+    <p class="c4">
+      <span>&ldquo;</span><span class="c12">Chain Signatures</span
+      ><span class="c0"
+        >&rdquo;: A cryptographic mechanism allowing NEAR accounts to sign
+        transactions on external blockchains.</span
+      >
+    </p>
+    <h2 class="c4 c7" id="h.28qhahkf5qe8">
+      <span>&ldquo;</span><span class="c12">Cross-Chain Settlement</span
+      ><span class="c0"
+        >&rdquo;: The process of finalizing Intent execution across multiple
+        blockchains.</span
+      >
+    </h2>
+    <h2 class="c4 c7" id="h.28qhahkf5qe8-1">
+      <span>&ldquo;</span><span class="c12">NEAR</span
+      ><span class="c0"
+        >&rdquo;: The sharded, developer-friendly, proof-of-stake, layer one
+        blockchain.</span
+      >
+    </h2>
+    <h2 class="c4 c7" id="h.yx7xm14s4wvq">
+      <span>&quot;</span><span class="c12">Protocol</span
+      ><span class="c0"
+        >&quot;: The NEAR Intents Protocol, a decentralized protocol on various
+        public blockchains that allows users to declare desired outcomes that
+        are executed by the Solver Network.
+      </span>
+    </h2>
+    <h2 class="c4 c7" id="h.j7b5q4olwp0y">
+      <span>&quot;</span><span class="c12">Liquidity Provider</span
+      ><span class="c0"
+        >&quot;: An individual or legal entity that supplies digital assets to
+        decentralized protocols to facilitate trading, swapping, or other
+        financial operations, and may receive fees or rewards in return.</span
+      >
+    </h2>
+    <h2 class="c7 c16" id="h.l3s067o6w37j">
+      <span>&quot;</span><span class="c12">Relayer</span
+      ><span class="c0"
+        >&quot;: A service that broadcasts transactions to the blockchain
+        networks on behalf of users, typically to optimize for gas costs or
+        improve transaction success rates.</span
+      >
+    </h2>
+    <ol class="c2 lst-kix_hy5l3i205ziq-0" start="2">
+      <li class="c4 c6 li-bullet-0"><span class="c5">Our Interfaces</span></li>
+    </ol>
+    <p class="c4">
+      <span
+        >The Interfaces are non-custodial tools that enable users to interact
+        with the Protocol by providing web or mobile-based access. Through the
+        Interfaces, users can declare desired outcomes (Intents) on various
+        public blockchains, including but not limited to Bitcoin, Ethereum,
+        Arbitrum, Base, Solana. These Intents are broadcast to a decentralized
+        network of AI-driven and human-operated Solvers that independently
+        analyze and compete to execute the Intents through optimal pathways
+        across supported blockchains.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >The Interfaces are &nbsp;designed to simplify blockchain interactions
+        by allowing users, services, or AI agents to declare high-level outcomes
+        they wish to achieve, rather than specifying the technical steps
+        required.
+      </span>
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >The Interfaces revolve around the concept of &quot;intents,&quot; which
+        are structured declarations containing key details such as the
+        initiator&#39;s NEAR account ID, the type of intent (e.g., token swap,
+        transfer), source assets and amounts, desired outcomes, unique
+        identifiers for tracking, and optional constraints like deadlines or
+        minimum outputs. These intents are broadcasted to a Solver Network,
+        where Solvers analyze and compete to provide the best execution plan.
+        Once a user approves a Solver&#39;s quote, the Intent is executed via a
+        smart contract on NEAR (intents.near), which handles the
+        transaction&mdash;including cross-chain operations if
+        necessary&mdash;while ensuring state changes are verified and reported
+        back to the originator. This abstraction streamlines complex blockchain
+        processes into an intuitive and efficient user experience.</span
+      >
+    </p>
+    <p class="c4">
+      <span
+        >The Interfaces are distinct from the Protocol and are one, but not the
+        exclusive, means of accessing the Protocol. </span
+      ><span>The Company</span
+      ><span
+        >&nbsp;does not control or operate any version of the Protocol on any
+        blockchain network. By using the Interfaces, you understand that you are
+        not buying or selling digital assets from us and that we do not operate
+        any liquidity pools on the Protocol or control trade execution on the
+        Protocol. </span
+      ><span
+        >When users pay fees for trades, and/or any Slippage, those fees may
+        accrue to Solvers, Liquidity Providers and Relayers for the
+        Protocol.</span
+      ><span>&nbsp;As a general matter, Solvers, L</span
+      ><span>iquidity providers and Relayers</span
+      ><span
+        >&nbsp;are independent third parties. The Protocol was initially
+        deployed on the NEAR blockchain </span
+      ><span>enabling</span
+      ><span class="c0"
+        >&nbsp;cross-chain functionality through Omni Bridge and any independent
+        third party bridge. These bridges facilitate asset transfers between
+        NEAR and supported networks (e.g., Bitcoin, Eth, Arbitrum, Base, Solana
+        and others).</span
+      >
+    </p>
+    <p class="c4">
+      <span
+        >To access the Interfaces, you must use a non-custodial wallet software,
+        which allows you to interact with public blockchains. Your relationship
+        with that non-custodial wallet provider is governed by the applicable
+        terms of service of that wallet provider. We do not have custody or
+        control over the contents of your wallet and have no ability to retrieve
+        or transfer its contents. By connecting your wallet to our Interfaces,
+        you agree to be bound by this Agreement and all of the terms
+        incorporated herein by reference.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >Solvers are independent actors, and Company does not:</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c0">(a) Guarantee optimal pricing or execution;</span>
+    </p>
+    <p class="c4">
+      <span>(b)</span><span>&nbsp;Assess </span
+      ><span class="c0">Solvers&rsquo; reliability or security;</span>
+    </p>
+    <p class="c4">
+      <span
+        >(c) Insure against losses from Solver errors, collusion, or malicious
+        acts.</span
+      >
+    </p>
+    <p class="c4">
+      <span>The Solver Network includes AI-driven, </span
+      ><span>algorithmic-driven</span
+      ><span
+        >&nbsp;and human-operated Solvers. AI Solvers may exhibit limitations
+        including algorithmic biases, unpredictable behaviors under certain
+        conditions, or optimization approaches that prioritize different factors
+        than you might expect. The Company does not develop, control, or
+        validate the decision-making processes of individual Solvers and assumes
+        no responsibility for their performance or outcomes.</span
+      >
+    </p>
+    <p class="c4">
+      <span
+        >To the extent that you elect to conduct transactions in connection with
+        the Interfaces, all transactions are conducted between you and the
+        relevant third party (Solver Network) and the Company is not a party to
+        them. The Company is not responsible for the quality, safety, accuracy,
+        or any aspect of the transaction (regardless of whether such transaction
+        is made available by the Interfaces) save where expressly
+        indicated.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1 start" start="1">
+      <li class="c4 c10 li-bullet-0">
+        <span class="c0">Other Interfaces</span>
+      </li>
+    </ol>
+    <p class="c4">
+      <span>We may from time to time in the future offer additional </span
+      ><span>Interfaces or products</span><span>, and such additional </span
+      ><span>Interfaces</span><span>&nbsp;shall be consi</span
+      ><span
+        >dered a product as used herein, regardless of whether such product is
+        specifically defined in this Agreement</span
+      ><span class="c0">.</span>
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="2">
+      <li class="c4 c10 li-bullet-0">
+        <span class="c0">Third Party Services and Content</span>
+      </li>
+    </ol>
+    <p class="c4">
+      <span>When you use any of our </span><span>Interfaces</span
+      ><span>, you may also be using the i</span><span>nterfaces, </span
+      ><span
+        >&nbsp;services or content of one or more third parties. Your use of
+        such third party i</span
+      ><span>nterfaces</span
+      ><span class="c0"
+        >, services or content may be subject to separate policies, terms of use
+        and fees of these third parties, and you agree to abide by and be
+        responsible for such policies, terms of use and fees, as
+        applicable.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-0" start="3">
+      <li class="c16 c6 c7 li-bullet-0">
+        <h1 id="h.mndoywvxix5o" style="display: inline">
+          <span class="c5"
+            >Modifications of this Agreement or Our Interfaces</span
+          >
+        </h1>
+      </li>
+    </ol>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1 start" start="1">
+      <li class="c8 c7 li-bullet-0">
+        <h1 id="h.rs160kfcswl0" style="display: inline">
+          <span class="c0">Modifications of this Agreement</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span
+        >We reserve the right, in our sole discretion, to modify this Agreement
+        from time to time. If we make any material modifications, we will notify
+        you by updating the date at the top of the Agreement and by maintaining
+        a current version of the Agreement at </span
+      ><span class="c14">[url for terms of service]</span
+      ><span class="c0">. </span>
+    </p>
+    <p class="c4">
+      <span
+        >All modifications will be effective when they are posted, and your
+        continued accessing or use of any of the </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;will serve as confirmation of your acceptance of those
+        modifications. If you do not agree with any modifications to this
+        Agreement, you must immediately stop accessing and using all of our </span
+      ><span>Interfaces</span><span class="c0">.</span>
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="2">
+      <li class="c8 c7 li-bullet-0">
+        <h1 id="h.woirnpx4f7k" style="display: inline">
+          <span class="c0">Modifications of Our Interfaces</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span
+        >We reserve the following rights, which do not constitute obligations of
+        ours: (a) with or without notice to you, to modify, substitute,
+        eliminate, restrict or add to any of the </span
+      ><span>Interfaces</span
+      ><span
+        >; (b) to review, modify, filter, disable, delete and remove any and all
+        content and information from any of the </span
+      ><span>Interfaces</span
+      ><span>; (c) to disable or modify access to access to the </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;at any time in the event of any breach of these Terms. You
+        acknowledge. understand, and agree that, from time to time, our </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >&nbsp;may be inaccessible or inoperable for any reason, including: (a)
+        equipment or technology or other infrastructure delay, inaccessibility,
+        or malfunctions; (b) periodic maintenance procedures or repairs that
+        Company or any of our suppliers or contractors may undertake from time
+        to time; (c) causes beyond Company&rsquo;s control or that Company could
+        not reasonably foresee; (d) disruptions and temporary or permanent
+        unavailability of underlying blockchain infrastructure; or (e)
+        unavailability of third-party service providers or external partners for
+        any reason.</span
+      >
+    </p>
+    <p class="c4">
+      <span
+        >Without limitation of any other provision of these Terms, and as set
+        forth below, Company has no responsibility or liability for any losses
+        or other injuries resulting from any such events.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >The Protocol may undergo changes, updates, or modifications through
+        technical upgrades, community governance decisions, or other processes
+        outside the Company&#39;s control. Such changes could affect
+        functionality, compatibility, or availability of features accessible
+        through the Interfaces, and the Company provides no guarantee of
+        continued compatibility between the Interfaces and all Protocol
+        versions. You acknowledge that certain changes to the Protocol may
+        require corresponding updates to the Interfaces or significantly alter
+        the user experience, and accept this as an inherent risk of interacting
+        with evolving blockchain technology.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-0" start="4">
+      <li class="c4 c6 c7 li-bullet-0">
+        <h1 id="h.vk0womjwu2pe" style="display: inline">
+          <span class="c5">Intellectual Property Rights</span>
+        </h1>
+      </li>
+    </ol>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1 start" start="1">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.i2sf7245a3i3" style="display: inline">
+          <span>I</span><span class="c0">P Rights Generally</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span
+        >As between you and the Company, we own all intellectual property and
+        other rights in and to each of our </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;and its respective contents, including, but not limited to,
+        software (including in the Interface), text, images, trademarks, service
+        marks, copyrights, patents, designs, and its &quot;look and feel.&quot;
+        The software code powering the Interfaces is open&#8208;source and
+        available under the MIT License, but the hosted service provided by the
+        Company via the Interfaces is subject to these Terms. Subject to the
+        terms of this Agreement, we grant you a limited, revocable,
+        non-exclusive, non-sublicensable, non-transferable license to access and
+        use our </span
+      ><span>Interfaces</span
+      ><span class="c0">&nbsp;solely in accordance with this Agreement. </span>
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >While the software code powering the Interfaces is open-source and
+        available under the MIT License, the Company retains all intellectual
+        property rights to the visual design, branding elements, and user
+        experience of the Interfaces. Users may fork and modify the open-source
+        code in accordance with the MIT License, but may not use the
+        Company&#39;s trademarks or branding in derivative works without
+        permission. Your use of the hosted Interfaces provided by the Company is
+        governed by these Terms, while any independent deployment of the
+        open-source code is governed by the applicable open-source
+        license.</span
+      >
+    </p>
+    <p class="c4">
+      <span
+        >You agree that you will not use, modify, distribute, tamper with,
+        reverse engineer, disassemble or decompile any of our </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;for any purpose other than as expressly permitted pursuant to
+        this Agreement. Except as set forth in this Agreement, we grant you no
+        right, title or interest in or to any of our </span
+      ><span>Interfaces</span
+      ><span
+        >, including any intellectual property rights. You understand and
+        acknowledge that the Protocol is not an </span
+      ><span>Interface and</span
+      ><span class="c0">&nbsp;we do not control the Protocol.</span>
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="2">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.94t793idfttn" style="display: inline">
+          <span class="c0">Third-Party Resources and Promotions</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span>Our </span><span>Interfaces</span
+      ><span
+        >&nbsp;may contain references or links to third-party resources,
+        including, but not limited to, information, materials, products, or
+        services, that we do not own or control. In addition, third parties may
+        offer promotions related to your access and use of our </span
+      ><span>Interfaces</span
+      ><span
+        >. We do not approve, monitor, endorse, warrant or assume any
+        responsibility for any such resources or promotions. If you access any
+        such resources or participate in any such promotions, you do so at your
+        own risk, and you understand that this Agreement does not apply to your
+        dealings or relationships with any third parties. You expressly relieve
+        us of any and all liability arising from your use of any such resources
+        or participation in any such promotions, and you shall not use our </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >&nbsp;in combination with any third party products or services in any
+        manner that would infringe or otherwise violate the intellectual
+        property rights of any third party or violate any applicable law.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="3">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.qlr1cwf9dzpx" style="display: inline">
+          <span class="c18">Additional Rights</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span class="c0"
+        >We reserve the right to cooperate with any law enforcement, court or
+        government investigation or order or third party requesting or directing
+        that we disclose information or content or information that you
+        provide.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-0" start="5">
+      <li class="c4 c6 c7 li-bullet-0">
+        <h1 id="h.jn69jebxpxz" style="display: inline">
+          <span class="c5">Your Responsibilities</span>
+        </h1>
+      </li>
+    </ol>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1 start" start="1">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.bgvkzy7apfff" style="display: inline">
+          <span class="c0">Prohibited Activity</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span class="c0"
+        >You agree not to engage in, or attempt to engage in, any of the
+        following categories of prohibited activity in relation to your access
+        and use of the Interfaces:</span
+      >
+    </p>
+    <ol class="c2 lst-kix_q2k6dq6ukorq-0 start" start="1">
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Intellectual Property Infringement.</span
+        ><span class="c0"
+          >&nbsp;Activity that infringes on or violates any copyright,
+          trademark, service mark, patent, right of publicity, right of privacy,
+          or other proprietary or intellectual property rights under applicable
+          law in any jurisdiction in the world.</span
+        >
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Data Privacy</span><span>.</span
+        ><span class="c0"
+          >&nbsp;Activity that violates any applicable laws, and contractual and
+          fiduciary obligations relating to the collection, storage, use,
+          transfer and any other processing of any personal information or any
+          other sensitive or confidential information.</span
+        >
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Cyberattack.</span
+        ><span
+          >&nbsp;Activity that seeks to interfere with or compromise the
+          integrity, security, or proper functioning of any computer, server,
+          network, personal device, or other information technology system,
+          including, but not limited to, the deployment of viruses and denial of
+          service attacks. Activity that uses any robot, spider, crawler,
+          scraper or other automated means or interface not provided by us to
+          access the </span
+        ><span>Interfaces</span
+        ><span
+          >&nbsp;to introduce any malware, virus, Trojan horse, worm, logic
+          bomb, drop-dead device, backdoor, shutdown mechanism or other harmful
+          material into the Interface or the </span
+        ><span>Interfaces</span><span class="c0">.</span>
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Fraud and Misrepresentation.</span
+        ><span
+          >&nbsp;Activity that seeks to defraud us or any other person or
+          entity, including, but not limited to, providing any false,
+          inaccurate, or misleading information in order to unlawfully obtain
+          the property of another, or to defraud Company, other users of the </span
+        ><span>Interfaces</span
+        ><span class="c0">&nbsp;or any other person.</span>
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Market Manipulation</span><span class="c12">.</span
+        ><span class="c0"
+          >&nbsp;Activity that violates any applicable law, rule, or regulation
+          concerning the integrity of trading markets, including, but not
+          limited to: the manipulative tactics commonly known as &quot;rug
+          pulls&quot;; pumping and dumping; wash trading; front-running;
+          accommodation trading; fictitious transactions; pre-arranged or
+          non-competitive transactions; cornering or attempting cornering of
+          digital assets; violations of bids or offers; spoofing; knowingly
+          making any bid or offer for the purpose of making a market price that
+          does not reflect the true state of the market; entering orders for the
+          purpose of entering into transactions without a net change in either
+          party&rsquo;s open positions but a resulting profit to one party and a
+          loss to the other party, commonly known as a &ldquo;money pass&rdquo;;
+          any other manipulation or fraudulent act or scheme to defraud,
+          deceive, trick or mislead; or any other trading activity that, in the
+          reasonable judgment of Company, is abusive, improper or disruptive to
+          the operation of the Interfaces.</span
+        >
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Securities and Derivatives Violations. </span
+        ><span class="c0"
+          >Activity that violates any applicable law, rule, or regulation
+          concerning the trading of securities or derivatives, including, but
+          not limited to, the unregistered offering of securities and the
+          offering of leveraged and margined commodity products to retail
+          customers in the United States.</span
+        >
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Sale of Stolen Property. </span
+        ><span
+          >Buying, selling, or transferring of stolen items, fraudulently
+          obtained items, items taken without authorization, and/or any other
+          illegally obtained items. Using or accessing the </span
+        ><span>Interfaces</span
+        ><span class="c0"
+          >&nbsp;to transmit or exchange digital assets that are the direct or
+          indirect proceeds of any criminal or fraudulent activity, including
+          terrorism or tax evasion.</span
+        >
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Data Mining or Scraping. </span
+        ><span
+          >Activity that involves data mining, robots, scraping, or similar data
+          gathering or extraction methods of content or information from any of
+          our </span
+        ><span>Interfaces</span><span class="c0">.</span>
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Objectionable Content.</span
+        ><span class="c0"
+          >&nbsp;Activity that involves soliciting information from anyone under
+          the age of 18 or that is otherwise harmful, threatening, abusive,
+          harassing, tortious, excessively violent, defamatory, vulgar, obscene,
+          pornographic, libelous, invasive of another&#39;s privacy, hateful,
+          discriminatory, or otherwise objectionable.</span
+        >
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Disruptive Content.</span
+        ><span
+          >&nbsp;Activity that could interfere with, disrupt, negatively affect,
+          or inhibit other users from fully enjoying the </span
+        ><span>Interfaces</span
+        ><span class="c0"
+          >, or that could damage, disable, overburden, or impair the
+          functioning of the Interfaces in any manner</span
+        >
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Circumvention of Content-Filtering. </span
+        ><span class="c0"
+          >Activity that circumvents any content-filtering techniques, security
+          measures or access controls that Company employs on the Interfaces,
+          including through the use of a VPN.</span
+        >
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Any Other Unlawful Conduct.</span
+        ><span class="c0"
+          >&nbsp;Activity that violates any applicable law, rule, or regulation
+          of &nbsp;Gibraltar, United States or another relevant jurisdiction,
+          including, but not limited to, the restrictions and regulatory
+          requirements imposed by U.S. law, including any relevant and
+          applicable anti-money laundering and anti-terrorist financing laws and
+          sanctions programs, such as the Bank Secrecy Act and the U.S.
+          Department of Treasury&rsquo;s Office of Foreign Asset Controls.
+          Activity from a jurisdiction (including an IP address in a
+          jurisdiction) that we have, in our sole discretion, determined is a
+          jurisdiction where the use of the Site, the Interfaces are prohibited,
+          including any Restricted Territory, or any activity with a Sanctioned
+          Person.</span
+        >
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Intent Manipulation</span
+        ><span class="c0"
+          >: Submitting Intents with falsified parameters, spam, or economically
+          unfeasible constraints.</span
+        >
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Solver Abuse</span
+        ><span class="c0"
+          >: Interfering with Solver operations (e.g., front-running, quote
+          spamming).</span
+        >
+      </li>
+      <li class="c4 c6 li-bullet-0">
+        <span class="c9">Cross-Chain Exploits</span
+        ><span
+          >: Leveraging settlement delays or bridge vulnerabilities for
+          arbitrage.</span
+        >
+      </li>
+    </ol>
+    <p class="c4">
+      <span>As a further condition to accessing or using the </span
+      ><span>Interfaces</span
+      ><span
+        >, you affirm that you will only transfer legally-obtained digital
+        assets that belong to you and that any digital assets you use in
+        connection with the </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >&nbsp;are either owned by you or you are validly authorized to carry
+        out actions using such digital assets.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="2">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.etz9x24w7u32" style="display: inline">
+          <span class="c0">Trading &ldquo; Swaps&rdquo;</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c16">
+      <span
+        >You agree and understand that: (a) all trades you submit through any of
+        our </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >&nbsp;are considered unsolicited, which means that they are solely
+        initiated by you; (b) you have not received any investment advice from
+        us in connection with any trades; and (c) we do not conduct a
+        suitability review of any trades you submit.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="3">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.6u9bsbyvh7bx" style="display: inline">
+          <span class="c0">Non-Custodial and No Fiduciary Duties</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span>Each of the </span><span>Interfaces</span
+      ><span
+        >&nbsp;is a purely non-custodial application, meaning we do not ever
+        have custody, possession, or control of your digital assets at any time.
+        It further means you are solely responsible for the custody of the
+        cryptographic private keys to the digital asset wallets you hold and you
+        should never share your wallet credentials or seed phrase with anyone.
+        We accept no responsibility for, or liability to you, in connection with
+        your use of a wallet and make no representations or warranties regarding
+        how any of our </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;will operate with any specific wallet. The Company has no control
+        over, or liability for, the delivery, quality, safety, legality, or any
+        other aspect of any digital assets that you may transfer to or from a
+        third party, and we are not responsible for ensuring that an entity with
+        whom you transact completes the transaction or is authorized to do so,
+        and if you experience a problem with any transactions in digital assets
+        using the </span
+      ><span>Interfaces</span
+      ><span class="c0">, then you bear the entire risk.</span>
+    </p>
+    <p class="c4">
+      <span
+        >Likewise, you are solely responsible for any associated wallet and we
+        are not liable for any acts or omissions by you in connection with or as
+        a result of your wallet being compromised. </span
+      ><span>The company</span
+      ><span
+        >&nbsp;does not act as an agent for you or any other user of the </span
+      ><span>Interfaces</span
+      ><span>&nbsp;and you are solely responsible for your use of the </span
+      ><span>Interfaces</span
+      ><span class="c0">, including all your transfers of digital assets.</span>
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >This Agreement is not intended to, and does not, create or impose any
+        fiduciary duties on us. To the fullest extent permitted by law, you
+        acknowledge and agree that we owe no fiduciary duties or liabilities to
+        you or any other party, and that to the extent any such duties or
+        liabilities may exist at law or in equity, those duties and liabilities
+        are hereby irrevocably disclaimed, waived, and eliminated. You further
+        agree that the only duties and obligations that we owe you are those set
+        out expressly in this Agreement.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="4">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.fyllh0ippfdn" style="display: inline">
+          <span class="c0">Compliance and Tax Obligations</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span>One or more of our </span><span>Interfaces</span
+      ><span
+        >&nbsp;may not be available for use in your jurisdiction. By accessing
+        or using any of our </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >, you agree that you are solely and entirely responsible for compliance
+        with all laws and regulations that may apply to you. The cross-border
+        nature of blockchain technology means transactions may implicate laws
+        from multiple jurisdictions simultaneously. The Company makes no
+        representations regarding the legality of the Protocol or Interfaces in
+        any specific jurisdiction.</span
+      >
+    </p>
+    <p class="c4">
+      <span>Specifically, your use of our </span><span>Interfaces</span
+      ><span class="c0"
+        >&nbsp;or the Protocol may result in various tax consequences, such as
+        income or capital gains tax, value-added tax, goods and services tax, or
+        sales tax in certain jurisdictions. It is your responsibility to
+        determine whether taxes apply to any transactions you initiate or
+        receive and, if so, to report and/or remit the correct tax to the
+        appropriate tax authority. It is recommended that you consult a tax
+        professional to understand the tax implications of your transactions, as
+        cryptocurrency and cross-chain transactions can be complex and vary by
+        jurisdiction.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="5">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.uxvj9mjgc5ed" style="display: inline">
+          <span class="c0">Gas Fees, Price Estimates, and Slippage</span>
+        </h1>
+      </li>
+    </ol>
+    <h2 class="c4 c7" id="h.8ab8xahsz3iv">
+      <span
+        >Blockchain transactions require the payment of transaction fees to the
+        appropriate network (&quot;</span
+      ><span class="c12">Gas Fees</span
+      ><span
+        >&quot;). Except as otherwise expressly set forth in the terms of
+        another offer by the Company, you will be solely responsible to pay the
+        Gas Fees for any transaction that you initiate via any of our </span
+      ><span>Interfaces</span
+      ><span
+        >. Although we attempt to provide accurate fee information, this
+        information reflects our estimates of fees, which may vary from the
+        actual fees paid to use the </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;and interact with the Bitcoin, Ethereum, Arbitrum, Base,
+        Solana</span
+      ><span>, </span><span class="c0">and other blockchains.</span>
+    </h2>
+    <p class="c4">
+      <span class="c0"
+        >When executing trades through the Interfaces, you may experience
+        Slippage&mdash;the difference between the quoted price and the execution
+        price. Slippage may be more pronounced in cross-chain transactions where
+        market conditions may change during the settlement period. You
+        acknowledge that the final execution price may differ from the initially
+        displayed quote, and that neither the Company nor the Protocol
+        guarantees execution at the quoted price.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="6">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.w4351nqfowao" style="display: inline">
+          <span class="c0">Release of Claims</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span
+        >You expressly agree that you assume all risks in connection with your
+        access and use of any of our </span
+      ><span>Interfaces</span
+      ><span
+        >. You further expressly waive and release us from any and all
+        liability, claims, causes of action, or damages arising from or in any
+        way relating to your use of any of our </span
+      ><span>Interfaces</span><span>. </span
+      ><span
+        >If you are a California resident, you waive the benefits and
+        protections of California Civil Code &sect; 1542, which provides:
+        &quot;[a] general release does not extend to claims that the creditor or
+        releasing party does not know or suspect to exist in his or her favor at
+        the time of executing the release and that, if known by him or her,
+        would have materially affected his or her settlement with the debtor or
+        released party.&quot;</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-0" start="6">
+      <li class="c4 c6 c7 li-bullet-0">
+        <h1 id="h.u0itg331km5g" style="display: inline">
+          <span class="c5">Disclaimers</span>
+        </h1>
+      </li>
+    </ol>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1 start" start="1">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.fcgruoum9lbz" style="display: inline">
+          <span class="c0">Assumption of Risk -- Generally</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span>The company </span><span>is a developer of software. </span
+      ><span>The company</span
+      ><span
+        >&nbsp;does not operate a digital asset or derivatives exchange platform
+        or offer trade execution or clearing services and has no oversight,
+        involvement, or control concerning your transactions using the </span
+      ><span>Interfaces</span
+      ><span
+        >. All transactions between users of the interface are executed
+        peer-to-peer directly between the users&rsquo; addresses through a </span
+      ><span>smart contract</span
+      ><span class="c0"
+        >. You are responsible for complying with all applicable laws that
+        govern your digital assets.</span
+      >
+    </p>
+    <p class="c4">
+      <span>By accessing and using any of our </span><span>Interfaces</span
+      ><span class="c0"
+        >, you represent that you are financially and technically sophisticated
+        enough to understand the inherent risks associated with using
+        cryptographic and blockchain-based systems, and that you have a working
+        knowledge of the usage and intricacies of digital assets such as ether
+        (ETH), Bitcoin (BTC), Solana (SOL), Arbitrum (ARB) and TON (this list is
+        non-exhaustive), so-called stablecoins, and other digital tokens such as
+        those following the Ethereum token standard (ERC-20) or any other token
+        standard, including NEP-141, for example.
+      </span>
+    </p>
+    <p class="c4">
+      <span
+        >You acknowledge and understand the inherent risks associated with
+        cryptographic systems and blockchain-based networks. </span
+      ><span>The company</span
+      ><span
+        >&nbsp;does not own or control any of the underlying software through
+        which blockchain networks are formed. In general, the software
+        underlying blockchain networks, including the Bitcoin, Ethereum,
+        Arbitrum, Base, Solana, and TON blockchains (this list is non-exhaustive
+        and includes any and all open-source blockchains), is open-source, such
+        that anyone can use, copy, modify, and distribute it. By using the </span
+      ><span>Interfaces</span
+      ><span
+        >, you acknowledge and agree (a) that the Company is not responsible for
+        the operation of the blockchain-based software and networks underlying
+        the </span
+      ><span>Interfaces</span
+      ><span
+        >, (b) that there exists no guarantee of the functionality, security, or
+        availability of that software and networks, and (c) that the underlying
+        blockchain-based networks are subject to sudden changes in operating
+        rules, such as those commonly referred to as &ldquo;forks,&rdquo; which
+        may materially affect the </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >. Blockchain networks use public and private key cryptography. You
+        alone are responsible for securing your private key(s). We do not have
+        access to your private key(s). Losing control of your private key(s)
+        will permanently and irreversibly deny you access to digital assets on
+        the Bitcoin, Ethereum, Arbitrum, Base, Solana, and TON blockchains or
+        other blockchain-based networks. Neither the Company, the Protocol nor
+        any other person or entity will be able to retrieve or protect your
+        digital assets. If your private key(s) are lost, then you will not be
+        able to transfer your digital assets to any other blockchain address or
+        wallet. If this occurs, then you will not be able to realize any value
+        or utility from the digital assets that you may hold.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >Further, you acknowledge and understand that the markets for these
+        digital assets are nascent and highly volatile due to risk factors
+        including, but not limited to, adoption, speculation, technology,
+        security, and regulation. You understand that anyone can create a token,
+        including fake versions of existing tokens and tokens that falsely claim
+        to represent projects, and acknowledge and understand the risk that you
+        may mistakenly trade those or other tokens. So-called stablecoins may
+        not be as stable as they purport to be, may not be fully or adequately
+        collateralized, and may be subject to panics and runs.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >Further, you acknowledge and understand that smart contract
+        transactions automatically execute and settle, and that blockchain-based
+        transactions are irreversible when confirmed. You acknowledge and
+        understand that you are responsible for all trades you place, including
+        any erroneous orders that may be filled. We do not take any action to
+        resolve erroneous trades that result from your errors. You acknowledge
+        and understand that the cost and speed of transacting with cryptographic
+        and blockchain-based systems such as Bitcoin, Ethereum, Arbitrum, Base,
+        Solana, TON and others are variable and may increase dramatically at any
+        time. You further acknowledge and understand the risk of selecting to
+        trade in expert modes, which can expose you to potentially significant
+        price slippage and higher costs.</span
+      >
+    </p>
+    <p class="c4">
+      <span>Further, you acknowledge and understand that the </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;and your digital assets could be impacted by one or more
+        regulatory inquiries or regulatory actions, which could impede or limit
+        the ability </span
+      ><span>of the Company</span
+      ><span
+        >&nbsp;to continue to make available our proprietary software and could
+        impede or limit your ability to access or use the </span
+      ><span>Interfaces</span><span class="c0">.</span>
+    </p>
+    <p class="c4">
+      <span
+        >Further, you acknowledge and understand that cryptography is a
+        progressing field with advances in code cracking or other technical
+        advancements, such as the development of quantum computers, which may
+        present risks to digital assets and the </span
+      ><span>Interfaces</span
+      ><span
+        >, and could result in the theft or loss of your digital assets. To the
+        extent possible, the smart contracts available on the interface will be
+        updated to account for any advances in cryptography and to incorporate
+        additional security measures necessary to address risks presented from
+        technological advancements, but that intention does not guarantee or
+        otherwise ensure full security of the </span
+      ><span>Interfaces</span><span class="c0">.</span>
+    </p>
+    <p class="c4">
+      <span
+        >Further, you understand that Bitcoin, Ethereum, Arbitrum, Base, Solana,
+        TON and other blockchain-based networks remain under development, which
+        creates technological and security risks when using the </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;in addition to uncertainty relating to digital assets and
+        transactions therein. You acknowledge that the cost of transacting on
+        the Bitcoin, Ethereum, Arbitrum, Base, Solana, TON and other
+        blockchain-based networks is variable and may increase at any time
+        causing impact to any activities taking place on Bitcoin, Ethereum,
+        Arbitrum, Base, Solana, TON or other blockchain-based networks, which
+        may result in price fluctuations or increased costs when using the </span
+      ><span>Interfaces</span><span class="c0">..</span>
+    </p>
+    <p class="c4">
+      <span>Further, you acknowledge and understand that the </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;are subject to flaws and that you are solely responsible for
+        evaluating any code provided relating to the </span
+      ><span>Interfaces</span
+      ><span
+        >. This warning and other warnings that the Company provides in these
+        terms are in no way evidence or represent an on-going duty to alert you
+        to all of the potential risks of utilizing the </span
+      ><span>Interfaces</span
+      ><span
+        >. Although we intend to provide accurate and timely information and
+        data, information available when using the </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;may not always be entirely accurate, complete, or current and may
+        also include technical inaccuracies or typographical errors. To continue
+        to provide you with as complete and accurate information as possible,
+        information may be changed or updated from time to time without notice,
+        including information regarding our policies. Accordingly, you
+        acknowledge and understand that you should verify all information before
+        relying on it, and all decisions based on information listed on the
+        Interfaces are your sole responsibility. No representation is made as to
+        the accuracy, completeness, or appropriateness for any particular
+        purpose of any pricing information distributed via the site or otherwise
+        when using the </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >. Prices and pricing information may be higher or lower than prices
+        available on platforms providing similar services.</span
+      >
+    </p>
+    <p class="c4">
+      <span
+        >We must comply with applicable laws, which may require us to, upon
+        request by government agencies, take certain actions or provide
+        information. You acknowledge and understand </span
+      ><span>that the Company</span
+      ><span class="c0"
+        >&nbsp;may in its sole discretion take any action it deems appropriate
+        to cooperate with government agencies or comply with applicable
+        laws.</span
+      >
+    </p>
+    <p class="c4">
+      <span>The u</span
+      ><span
+        >sers acknowledge that transactions executed through the Interfaces may
+        experience S</span
+      ><span>lippage</span
+      ><span
+        >, resulting in a final execution price different from the initially
+        displayed price. Slippage is inherent to cross chain transactions due to
+        factors such as market volatility, liquidity fluctuations, and
+        blockchain transaction delays. The Company and the Protocol </span
+      ><span>do not control or influence</span
+      ><span>&nbsp;the price at which transactions are executed and </span
+      ><span>are not responsible</span
+      ><span>&nbsp;for any financial losses resulting from slippage.</span>
+    </p>
+    <p class="c4">
+      <span
+        >Furthermore, the Interfaces facilitate cross-chain transactions through
+        third-party bridges such as Omni Bridge and Chain Signatures. These
+        bridges carry inherent risks, including but not limited to smart
+        contract vulnerabilities, governance risks, and the potential for asset
+        loss due to bridge failures or exploits. Chain Signatures depend on
+        cryptographic assumptions vulnerable to technological advances (e.g.,
+        quantum computing). Compromised signatures may result in irreversible
+        asset loss. </span
+      ><span>The company</span
+      ><span
+        >&nbsp;does not control Omni Bridge or Chain Signatures and disclaims
+        any liability for any losses or damages resulting from their use.</span
+      >
+    </p>
+    <p class="c4">
+      <span
+        >In summary, you acknowledge that We are not responsible for any of
+        these variables or risks, do not own or control the Protocol, and cannot
+        be held liable for any resulting losses that you experience while
+        accessing or using any of Our </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >. Accordingly, you understand and agree to assume full responsibility
+        for all of the risks of accessing and using the Interfaces to interact
+        with the Protocol. You hereby irrevocably waive, release and discharge
+        all claims, whether known or unknown to you, against the Company and Our
+        shareholders, members, directors, officers, employees, agents, and
+        representatives, suppliers, and contractors related to any of the risks
+        set forth in this Section 6 or elsewhere in these terms.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="2">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.ljpzfclo4olw" style="display: inline">
+          <span class="c0">No Warranties</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span>Each of Our </span><span>Interfaces</span
+      ><span
+        >&nbsp;are provided on an &quot;as is&quot; and &quot;as available&quot;
+        basis. To the fullest extent permitted by law, We disclaim any
+        representations and warranties of any kind, whether express, implied, or
+        statutory, including, but not limited to, the warranties of
+        merchantability and fitness for a particular purpose. You acknowledge
+        and understand that your use of each of our </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;is at your own risk. We do not represent or warrant that access
+        to any of our </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;will be continuous, uninterrupted, timely, or secure; that the
+        information contained in any of our </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;will be accurate, reliable, complete, or current; or that any of
+        our </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;will be free from errors, defects, viruses, or other harmful
+        elements, or that use of the </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;does not and will not infringe or otherwise violate the
+        intellectual property of any third party. No advice, information, or
+        statement that we make should be treated as creating any warranty
+        concerning any of our </span
+      ><span>Interfaces</span
+      ><span
+        >. We do not endorse, guarantee, or assume responsibility for any
+        advertisements, offers, or statements made by third parties concerning
+        any of our </span
+      ><span>Interfaces</span><span class="c0">.</span>
+    </p>
+    <p class="c4">
+      <span
+        >Similarly, the Protocol is provided &quot;as is&quot;, at your own
+        risk, and without warranties of any kind. We do not provide, own, or
+        control the Protocol, which is run autonomously without any headcount by
+        smart contracts deployed on various blockchains.</span
+      ><span>.</span
+      ><span
+        >&nbsp;No developer or entity involved in creating the Protocol will be
+        liable for any claims or damages whatsoever associated with your use,
+        inability to use, or your interaction with other users of, the Protocol,
+        including any direct, indirect, incidental, special, exemplary, punitive
+        or consequential damages, or loss of profits, cryptocurrencies, tokens,
+        or anything else of value. We do not endorse, guarantee, or assume
+        responsibility for any advertisements, offers, or statements made by
+        third parties concerning any of our </span
+      ><span>Interfaces</span><span class="c0">.</span>
+    </p>
+    <p class="c4">
+      <span
+        >You acknowledge and understand that data you provide while accessing or
+        using the </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >&nbsp;may become irretrievably lost or corrupted or temporarily
+        unavailable due to a variety of causes, and agree that, to the maximum
+        extent permitted under applicable law, we will not be liable for any
+        loss or damage caused by denial-of-service attacks, software failures,
+        viruses or other technologically harmful materials (including those
+        which may infect your computer equipment), protocol changes by
+        third-party providers, internet outages, force majeure events or other
+        disasters, scheduled or unscheduled maintenance, or other causes either
+        within or outside of our control.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >Any payments or financial transactions that you engage in will be
+        processed via automated smart contracts. Once executed, we have no
+        control over these payments or transactions, nor do we have the ability
+        to reverse any payments or transactions.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="3">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.dlu2tp423mc6" style="display: inline">
+          <span class="c0">No Investment Advice</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span>All information provided by any of our </span><span>Interfaces</span
+      ><span
+        >&nbsp;is for informational purposes only and should not be construed as
+        investment advice or a recommendation that a particular token is a safe
+        or sound investment. You should not take, or refrain from taking, any
+        action based on any information contained in any of our </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >. By providing token information for your convenience, we do not make
+        any trading, financial or investment recommendations to you or opine on
+        the merits of any transaction or opportunity. You alone are responsible
+        for determining whether any trading is appropriate for you based on your
+        personal investment objectives, financial circumstances, and risk
+        tolerance. You should seek professional advice before submitting a
+        transaction.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-0" start="7">
+      <li class="c4 c6 c7 li-bullet-0">
+        <h1 id="h.f1baiijnce4m" style="display: inline">
+          <span class="c5">Indemnification</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span
+        >You agree to hold harmless, release, defend, and indemnify us and our
+        officers, directors, employees, contractors, agents, affiliates, and
+        subsidiaries (collectively &ldquo;</span
+      ><span class="c12">Indemnified Parties</span
+      ><span
+        >&rdquo;) from and against all claims, damages, obligations, losses,
+        liabilities, costs, and expenses arising from: (a) your access and use
+        of any of our </span
+      ><span>Interfaces</span
+      ><span
+        >; (b) your violation of any term or condition of this Agreement, the
+        right of any third party, or any other applicable law, rule, or
+        regulation; (c) any other party&#39;s access and use of any of our </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;with your assistance or using any device or account that you own
+        or control; (d) digital assets associated with your wallet; (e) your
+        infringement, misappropriation, or other violation of the intellectual
+        property or other proprietary rights of any other person or entity; and
+        (f) any dispute between you and (i) any other user of any of the </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;or (ii) any of your own customers or users. If you are obligated
+        to indemnify any Indemnified Party, the Company (or, at our sole
+        discretion, the applicable Indemnified Party) will have the right, in
+        our or its sole discretion, to control any action or proceeding and to
+        determine whether the Company wishes to settle, and if so, on what
+        terms, and you agree to cooperate with the Company in the defense.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-0" start="8">
+      <li class="c16 c6 c7 li-bullet-0">
+        <h1 id="h.w6u7mmelmjg9" style="display: inline">
+          <span class="c5">Limitation of Damages and Liability</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span
+        >Under no circumstances shall We or any of our officers, directors,
+        employees, contractors, agents, affiliates, or subsidiaries be liable to
+        you for any indirect, punitive, incidental, special, consequential, or
+        exemplary damages, including, but not limited to, damages for loss of
+        profits, goodwill, use, data, fiat, revenue, opportunities, goodwill or
+        other intangible property, arising out of or relating to any access or
+        use of or inability to access or use any of the </span
+      ><span>Interfaces</span
+      ><span
+        >, nor will we be responsible for any damage, loss, or injury resulting
+        from hacking, tampering, or other unauthorized access or use of any of
+        the </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;or the information contained within it, whether such damages are
+        based in contract, tort, negligence, strict liability, or otherwise,
+        arising out of or in connection with authorized or unauthorized use of
+        any of the </span
+      ><span>Interfaces</span
+      ><span
+        >, even if an authorized representative of the Company has been advised
+        of or knew or should have known of the possibility of such damages. We
+        assume no liability or responsibility for any: (a) errors, mistakes, or
+        inaccuracies of content; (b) personal injury or property damage, of any
+        nature whatsoever, resulting from any access or use of the Interfaces;
+        (c) unauthorized access or use of any secure server or database in our
+        control, or the use of any information or data stored therein; (d)
+        interruption or cessation of function related to any of the </span
+      ><span>Interfaces</span
+      ><span
+        >; (e) bugs, viruses, trojan horses, or the like that may be transmitted
+        to or through the Interfaces; (f) errors or omissions in, or loss or
+        damage incurred as a result of the use of, any content made available
+        through any of the </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >; (g) the defamatory, offensive, or illegal conduct of any third party
+        and (h) causes beyond Company&rsquo;s control or that the Company could
+        not reasonably foresee.</span
+      >
+    </p>
+    <p class="c4">
+      <span
+        >We have no liability to you or to any third party for any claims or
+        damages that may arise as a result of any payments or transactions that
+        you engage in via any of our </span
+      ><span>Interfaces</span
+      ><span
+        >, or any other payment or transactions that you conduct via any of our </span
+      ><span>Interfaces</span
+      ><span
+        >. Except as expressly provided for herein, we do not provide refunds
+        for any purchases that you might make on or through any of our </span
+      ><span>Interfaces</span><span class="c0">.</span>
+    </p>
+    <p class="c4">
+      <span
+        >We make no warranties or representations, express or implied, about
+        linked third party services, the third parties they are owned and
+        operated by, the information contained on them, assets available through
+        them, or the suitability, privacy, or security of their </span
+      ><span>Interfaces</span
+      ><span
+        >&nbsp;or services. You acknowledge sole responsibility for and assume
+        all risk arising from your use of third-party services, third-party
+        websites, applications, or resources. We shall not be liable under any
+        circumstances for damages arising out of or in any way related to
+        software, </span
+      ><span>Interfaces</span
+      ><span
+        >, services, and/or information offered or provided by third-parties and
+        accessed through any of our </span
+      ><span>Interfaces</span><span class="c0">.</span>
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >Some jurisdictions do not allow the limitation of liability for
+        personal injury, or of incidental or consequential damages, so this
+        limitation may not apply to you. In no event shall our total liability
+        to you for all damages (other than as may be required by applicable law
+        in cases involving personal injury) exceed the amount of one hundred
+        U.S. dollars ($100.00 USD) or its equivalent in the local currency of
+        the applicable jurisdiction. The foregoing disclaimer will not apply to
+        the extent prohibited by law.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-0" start="9">
+      <li class="c4 c6 c7 li-bullet-0">
+        <h1 id="h.60bmgjqzwwb0" style="display: inline">
+          <span class="c5"
+            >Governing Law, Dispute Resolution and Class Action Waivers</span
+          >
+        </h1>
+      </li>
+    </ol>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1 start" start="1">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.1nvodm6iohzg" style="display: inline">
+          <span class="c5">Governing Law and Jurisdiction</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span class="c0"
+        >All matters relating to the Interfaces and these Terms of Service, and
+        any dispute or claim arising therefrom or related thereto (in each case,
+        including non-contractual disputes or claims), shall be governed by and
+        construed in accordance with the law of Gibraltar.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >Any legal suit, action, or proceeding arising out of, or related to,the
+        Interfaces and these Terms of Service shall be instituted exclusively in
+        the courts of the Gibraltar, although we retain the right to bring any
+        suit, action, or proceeding against you for breach of these Terms of
+        Service in your country of residence or any other relevant country. You
+        waive any and all objections to the exercise of jurisdiction over you by
+        such courts and to venue in such courts.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="2">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.2ryzu8bxegci" style="display: inline">
+          <span class="c5">Arbitration</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span class="c0"
+        >At our or our service providers&rsquo; sole discretion, as applicable,
+        we or they may require you to submit any disputes arising under these
+        Terms of Service, or in connection with your use of the
+        Interfaces&mdash;including disputes concerning their interpretation,
+        violation, invalidity, non-performance, or termination&mdash;to final
+        and binding arbitration under the Rules of Arbitration of the Gibraltar
+        Arbitration Act of 1895 and any amendments or successor legislation in
+        force at the time of the dispute.
+      </span>
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >ANY DISPUTE, CONTROVERSY OR CLAIM ARISING OUT OF, RELATING TO OR IN
+        CONNECTION WITH THESE TERMS, THE INTERFACES (OR ANY PORTION OR ALL OF
+        THE FOREGOING), INCLUDING THE BREACH, TERMINATION OR VALIDITY OF THESE
+        TERMS, SHALL BE FINALLY RESOLVED BY ARBITRATION. THE TRIBUNAL SHALL HAVE
+        THE POWER TO RULE ON ANY CHALLENGE TO ITS OWN JURISDICTION OR TO THE
+        VALIDITY OR ENFORCEABILITY OF ANY PORTION OF THE AGREEMENT TO ARBITRATE.
+        THE PARTIES AGREE TO ARBITRATE SOLELY ON AN INDIVIDUAL BASIS, AND THAT
+        THIS AGREEMENT DOES NOT PERMIT CLASS ARBITRATION OR ANY CLAIMS BROUGHT
+        AS A PLAINTIFF OR CLASS MEMBER IN ANY CLASS OR REPRESENTATIVE
+        ARBITRATION PROCEEDING. THE ARBITRAL TRIBUNAL MAY NOT CONSOLIDATE MORE
+        THAN ONE PERSON&rsquo;S CLAIMS, AND MAY NOT OTHERWISE PRESIDE OVER ANY
+        FORM OF A REPRESENTATIVE OR CLASS PROCEEDING.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="3">
+      <li class="c4 c10 c7 li-bullet-0">
+        <h1 id="h.4zd27o2lh9am" style="display: inline">
+          <span class="c0">Limitation on Time to File Claims</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span class="c0"
+        >ANY CAUSE OF ACTION OR CLAIM YOU MAY HAVE ARISING OUT OF OR RELATING TO
+        THESE TERMS OF USE OR THE INTERFACES MUST BE COMMENCED WITHIN ONE (1)
+        YEAR AFTER THE CAUSE OF ACTION ACCRUES, OTHERWISE, SUCH CAUSE OF ACTION
+        OR CLAIM IS PERMANENTLY BARRED.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="4">
+      <li class="c4 c7 c10 li-bullet-0">
+        <h1 id="h.yvg9pbkzf7p3" style="display: inline">
+          <span class="c0">Waiver and Severability</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span class="c0"
+        >No waiver by the Company of any term or condition set out in these
+        Terms of Service shall be deemed a further or continuing waiver of such
+        term or condition or a waiver of any other term or condition, and any
+        failure of Company to assert a right or provision under these Terms of
+        Service shall not constitute a waiver of such right or provision.</span
+      >
+    </p>
+    <p class="c4">
+      <span class="c0"
+        >If any provision of these Terms of Service is held by a court or other
+        tribunal of competent jurisdiction to be invalid, illegal or
+        unenforceable for any reason, such provision shall be eliminated or
+        limited to the minimum extent such that the remaining provisions of the
+        Terms of Service will continue in full force and effect.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-0" start="10">
+      <li class="c16 c6 c7 li-bullet-0">
+        <h1 id="h.24ccd6dmtyuw" style="display: inline">
+          <span class="c5">Miscellaneous</span>
+        </h1>
+      </li>
+    </ol>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1 start" start="1">
+      <li class="c8 c7 li-bullet-0">
+        <h1 id="h.1y9l1a7afvns" style="display: inline">
+          <span class="c0">Entire Agreement</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span class="c0"
+        >These terms constitute the entire agreement between you and Us with
+        respect to the subject matter hereof. This Agreement supersedes any and
+        all prior or contemporaneous written and oral agreements, communications
+        and other understandings (if any) relating to the subject matter of the
+        Terms.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="2">
+      <li class="c8 c7 li-bullet-0">
+        <h1 id="h.r8dxpbp0yu7x" style="display: inline">
+          <span class="c0"
+            >Not Registered with the SEC or Any Other Agency</span
+          >
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span
+        >The Interfaces are not financial platforms. We do not broker trades,
+        provide liquidity, or handle asset custody. All transactions occur
+        peer-to-peer via </span
+      ><span>smart contracts</span
+      ><span class="c0">&nbsp;on public blockchains.</span>
+    </p>
+    <p class="c4">
+      <span>We</span
+      ><span
+        >&nbsp;are not registered with the U.S. Securities and Exchange
+        Commission as a national securities exchange or in any other capacity.
+        You understand and acknowledge that we do not broker trading orders on
+        your behalf. We also do not facilitate the execution or settlement of
+        your trades, which occur entirely on public distributed blockchains like
+        Bitcoin, Ethereum, Solana, Arbitrum, NEAR, or TON. As a result, we do
+        not (and cannot) guarantee market best pricing or best execution through
+        our </span
+      ><span>Interfaces</span
+      ><span class="c0"
+        >. Any references in a product to &quot;best price&quot; does not
+        constitute a representation or warranty about pricing available through
+        such product, on the Protocol, or elsewhere.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="3">
+      <li class="c7 c8 li-bullet-0">
+        <h1 id="h.ptsr51nsjqbm" style="display: inline">
+          <span class="c0">Notice</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span class="c0"
+        >We may provide any notice to you under this Agreement using
+        commercially reasonable means, including using public communication
+        channels. Notices we provide by using public communication channels will
+        be effective upon posting.</span
+      >
+    </p>
+    <p class="c19">
+      <span
+        >If you have any questions about these Terms, please contact us at </span
+      ><span class="c3"
+        ><a class="c1" href="mailto:support@aurora.dev"
+          >support@aurora.dev</a
+        ></span
+      ><span>&nbsp;or </span
+      ><span class="c3"
+        ><a class="c1" href="mailto:legal@aurora.dev">legal@aurora.dev</a></span
+      ><span class="c0">. </span>
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="4">
+      <li class="c8 c7 li-bullet-0">
+        <h1 id="h.e15rwpua52vn" style="display: inline">
+          <span class="c0">Rights and Remedies</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span class="c0"
+        >Any right or remedy of the Company set forth in these Terms is in
+        addition to, and not in lieu of, any other right or remedy whether
+        described in these Terms, under applicable laws, at law, or in equity.
+        The failure or delay of Company in exercising any right, power, or
+        privilege under these Terms will not operate as a waiver thereof.</span
+      >
+    </p>
+    <ol class="c2 lst-kix_hy5l3i205ziq-1" start="5">
+      <li class="c8 c7 li-bullet-0">
+        <h1 id="h.mdnoslkp4orp" style="display: inline">
+          <span class="c0">Privacy Policy</span>
+        </h1>
+      </li>
+    </ol>
+    <p class="c4">
+      <span
+        >Your use of the Interfaces is subject to our Privacy Policy,
+        availa</span
+      ><span>ble at </span
+      ><span class="c3"
+        ><a
+          class="c1"
+          href="https://www.google.com/url?q=https://docs.google.com/document/d/1OwDrVEB1oh4_Fbl7FeXp-Q1z7crGuUXJ/edit&amp;sa=D&amp;source=editors&amp;ust=1741345309115317&amp;usg=AOvVaw3FHa3VCDgmkV4Yi-aRKcc3"
+          >Privacy Policy</a
+        ></span
+      ><span class="c0"
+        >. We may collect limited data, such as wallet addresses or usage
+        analytics, to operate and improve the Interfaces. We do not store
+        private keys or personal financial information, as the Interfaces are
+        non-custodial. You acknowledge that blockchain transactions are
+        inherently public and not controlled by the Company.&#8203;&#8203;</span
+      >
+    </p>
+    <p class="c11"><span class="c0"></span></p>
+    <p class="c11"><span class="c0"></span></p>
+    <p class="c11"><span class="c0"></span></p>
+    <p class="c11"><span class="c0"></span></p>
+  </body>
+</html>

--- a/src/app/privacy-policy/layout.tsx
+++ b/src/app/privacy-policy/layout.tsx
@@ -1,0 +1,14 @@
+import Layout from "@src/components/Layout"
+import { PreloadFeatureFlags } from "@src/components/PreloadFeatureFlags"
+import type React from "react"
+import type { PropsWithChildren } from "react"
+
+const PrivacyPolicyLayout: React.FC<PropsWithChildren> = ({ children }) => {
+  return (
+    <PreloadFeatureFlags>
+      <Layout>{children}</Layout>
+    </PreloadFeatureFlags>
+  )
+}
+
+export default PrivacyPolicyLayout

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import React from "react"
+
+export default function PrivacyPolicy() {
+  return (
+    <div className="flex justify-center items-center w-full">
+      <iframe
+        title="Privacy Policy"
+        src="/static/documents/privacy-policy.html"
+        height="700px"
+        className="h-screen md:h-full w-full max-w-[800px]"
+      />
+    </div>
+  )
+}

--- a/src/app/terms-and-conditions/layout.tsx
+++ b/src/app/terms-and-conditions/layout.tsx
@@ -1,0 +1,17 @@
+import type React from "react"
+import type { PropsWithChildren } from "react"
+
+import Layout from "@src/components/Layout"
+import { PreloadFeatureFlags } from "@src/components/PreloadFeatureFlags"
+
+const TermsAndConditionsLayout: React.FC<PropsWithChildren> = ({
+  children,
+}) => {
+  return (
+    <PreloadFeatureFlags>
+      <Layout>{children}</Layout>
+    </PreloadFeatureFlags>
+  )
+}
+
+export default TermsAndConditionsLayout

--- a/src/app/terms-and-conditions/page.tsx
+++ b/src/app/terms-and-conditions/page.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import React from "react"
+
+export default function TermsAndConditions() {
+  return (
+    <div className="flex justify-center items-center w-full">
+      <iframe
+        title="Terms and Conditions"
+        src="/static/documents/terms-of-service.html"
+        height="700px"
+        className="h-screen md:h-full w-full max-w-[800px]"
+      />
+    </div>
+  )
+}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -79,6 +79,23 @@ const Settings = () => {
                 <ExternalLinkIcon width={16} height={16} />
               </a>
 
+              <a
+                href="/privacy-policy"
+                className="w-full flex justify-between items-center gap-2"
+              >
+                <Text size="2" weight="medium">
+                  Privacy Policy
+                </Text>
+              </a>
+
+              <a
+                href="/terms-and-conditions"
+                className="w-full flex justify-between items-center gap-2"
+              >
+                <Text size="2" weight="medium">
+                  Terms and Conditions
+                </Text>
+              </a>
               {whitelabelTemplate === "near-intents" && (
                 <a
                   href="/jobs"


### PR DESCRIPTION
Exported HTML natively from Google Docs, rendered in an iframe. It should keep exactly the same formatting as seeing it 
on Google Docs.

TODO: 
- [x] Add Terms and Conditions page

![image](https://github.com/user-attachments/assets/cc28acfa-820f-421b-9e6c-bffa62eeea9b)
![image](https://github.com/user-attachments/assets/3954f90f-1e28-48bd-a776-90f5ec0c25a3)
