### PR TITLE
feat: allow storing iv or pKey for OTC trades

### DIFF
--- a/src/app/api/otc_trades/[tradeId]/route.ts
+++ b/src/app/api/otc_trades/[tradeId]/route.ts
@@ -15,7 +15,7 @@ export async function GET(
 
     const { data, error } = await supabase
       .from("otc_trades")
-      .select("encrypted_payload, iv")
+      .select("encrypted_payload, iv, p_key")
       .eq("trade_id", parsedTradeId)
       .maybeSingle()
 
@@ -37,6 +37,7 @@ export async function GET(
     return NextResponse.json({
       encrypted_payload: data.encrypted_payload,
       iv: data.iv,
+      p_key: data.p_key,
     } satisfies GetOtcTradeResponse)
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/src/app/api/otc_trades/_utils/validation.ts
+++ b/src/app/api/otc_trades/_utils/validation.ts
@@ -1,12 +1,15 @@
 import { z } from "zod"
 
-export const tradeIdSchema = z.string().refine(
-  (val) => {
-    return /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-      val
-    )
-  },
-  {
-    message: "Invalid trade_id format",
-  }
-)
+export const tradeIdSchema = z
+  .string()
+  .uuid()
+  .refine(
+    (val) => {
+      const version = val[14]
+      // Need to support both UUID v4 and v5 for backwards compatibility
+      return version === "4" || version === "5"
+    },
+    {
+      message: "Invalid trade_id format",
+    }
+  )

--- a/src/app/api/otc_trades/route.test.ts
+++ b/src/app/api/otc_trades/route.test.ts
@@ -34,6 +34,7 @@ describe("POST /api/otc_trades", () => {
       new Request(`${TEST_BASE_URL}/api/otc_trades`, {
         method: "POST",
         body: JSON.stringify({
+          trade_id: "09e02623-d6b7-59be-ae65-0f562986ea14",
           encrypted_payload:
             "DMlO/ObmxvFplP8Xm6k7g5V0XFZd8PfAzJdX5hgBupHYW3odASMe/B/v2+zQdQw9Tu2cADi9H0oUfbK4gGHD79ik0WlIpAkQlJXPHkloqF8xLAVJZkn9i4KduNOKTIDGA58rEcN8v+dZd1kYiKAyH9t4fpzTsxYcI0bJNQIOvVwE4K/TB7MHw/nnbkiNvVWSuwVroQJ0Hw5eNQxfKfmhC6IutBmTP6aQCEMWtKAb6jkgEbSy3MIl/xzEAVFgk+BP/rWYjoGX3xgot6LhVEuZNe3aZDpLvwvdURUVwDwN6ABMBhYNW9u1Vmphk4r6qAD9HUuKltozBjX90q04G9VwGG9bkAqebnOvSrBwW3iXgEXQcMiQ9id2BvT7zfWFOUgelOlEfPwxQy+wnElx8NsP1RXXaOdp4ZgH6SzLOrh/2Lb6nKGn4s/d1G3yNLr+9GiOF3IySxiBZB6D17OPFFWm3ZmyoH3tpE5SkH1PAQRBYf3S+dKvbmE/8uvICvzoCcIvXU+O7W45sZIz9aloNERTG0hRxEfRAqLuMQG/WeQ5rLyJJzG2AUXe0AScO2KJD85xEdVM+JR0n6qCvfWkOmZkIQ==",
           iv: "e9QTDukeRo97zGVZ",
@@ -59,6 +60,7 @@ describe("POST /api/otc_trades", () => {
       new Request(`${TEST_BASE_URL}/api/otc_trades`, {
         method: "POST",
         body: JSON.stringify({
+          trade_id: "09e02623-d6b7-59be-ae65-0f562986ea14",
           encrypted_payload:
             "DMlO/ObmxvFplP8Xm6k7g5V0XFZd8PfAzJdX5hgBupHYW3odASMe/B/v2+zQdQw9Tu2cADi9H0oUfbK4gGHD79ik0WlIpAkQlJXPHkloqF8xLAVJZkn9i4KduNOKTIDGA58rEcN8v+dZd1kYiKAyH9t4fpzTsxYcI0bJNQIOvVwE4K/TB7MHw/nnbkiNvVWSuwVroQJ0Hw5eNQxfKfmhC6IutBmTP6aQCEMWtKAb6jkgEbSy3MIl/xzEAVFgk+BP/rWYjoGX3xgot6LhVEuZNe3aZDpLvwvdURUVwDwN6ABMBhYNW9u1Vmphk4r6qAD9HUuKltozBjX90q04G9VwGG9bkAqebnOvSrBwW3iXgEXQcMiQ9id2BvT7zfWFOUgelOlEfPwxQy+wnElx8NsP1RXXaOdp4ZgH6SzLOrh/2Lb6nKGn4s/d1G3yNLr+9GiOF3IySxiBZB6D17OPFFWm3ZmyoH3tpE5SkH1PAQRBYf3S+dKvbmE/8uvICvzoCcIvXU+O7W45sZIz9aloNERTG0hRxEfRAqLuMQG/WeQ5rLyJJzG2AUXe0AScO2KJD85xEdVM+JR0n6qCvfWkOmZkIQ==",
           p_key: "oNn2ERFTt5qfeqHeY8zKsO5CxfECNl8AhWvdRdD38sw",
@@ -77,6 +79,7 @@ describe("POST /api/otc_trades", () => {
       new Request(`${TEST_BASE_URL}/api/otc_trades`, {
         method: "POST",
         body: JSON.stringify({
+          trade_id: "09e02623-d6b7-59be-ae65-0f562986ea14",
           encrypted_payload: "invalid aes256",
           iv: "invalid iv",
         }),
@@ -100,6 +103,7 @@ describe("POST /api/otc_trades", () => {
       new Request(`${TEST_BASE_URL}/api/otc_trades`, {
         method: "POST",
         body: JSON.stringify({
+          trade_id: "09e02623-d6b7-59be-ae65-0f562986ea14",
           encrypted_payload:
             "DMlO/ObmxvFplP8Xm6k7g5V0XFZd8PfAzJdX5hgBupHYW3odASMe/B/v2+zQdQw9Tu2cADi9H0oUfbK4gGHD79ik0WlIpAkQlJXPHkloqF8xLAVJZkn9i4KduNOKTIDGA58rEcN8v+dZd1kYiKAyH9t4fpzTsxYcI0bJNQIOvVwE4K/TB7MHw/nnbkiNvVWSuwVroQJ0Hw5eNQxfKfmhC6IutBmTP6aQCEMWtKAb6jkgEbSy3MIl/xzEAVFgk+BP/rWYjoGX3xgot6LhVEuZNe3aZDpLvwvdURUVwDwN6ABMBhYNW9u1Vmphk4r6qAD9HUuKltozBjX90q04G9VwGG9bkAqebnOvSrBwW3iXgEXQcMiQ9id2BvT7zfWFOUgelOlEfPwxQy+wnElx8NsP1RXXaOdp4ZgH6SzLOrh/2Lb6nKGn4s/d1G3yNLr+9GiOF3IySxiBZB6D17OPFFWm3ZmyoH3tpE5SkH1PAQRBYf3S+dKvbmE/8uvICvzoCcIvXU+O7W45sZIz9aloNERTG0hRxEfRAqLuMQG/WeQ5rLyJJzG2AUXe0AScO2KJD85xEdVM+JR0n6qCvfWkOmZkIQ==",
           iv: "e9QTDukeRo97zGVZ",
@@ -119,6 +123,7 @@ describe("POST /api/otc_trades", () => {
       new Request(`${TEST_BASE_URL}/api/otc_trades`, {
         method: "POST",
         body: JSON.stringify({
+          trade_id: "09e02623-d6b7-59be-ae65-0f562986ea14",
           encrypted_payload:
             "DMlO/ObmxvFplP8Xm6k7g5V0XFZd8PfAzJdX5hgBupHYW3odASMe/B/v2+zQdQw9Tu2cADi9H0oUfbK4gGHD79ik0WlIpAkQlJXPHkloqF8xLAVJZkn9i4KduNOKTIDGA58rEcN8v+dZd1kYiKAyH9t4fpzTsxYcI0bJNQIOvVwE4K/TB7MHw/nnbkiNvVWSuwVroQJ0Hw5eNQxfKfmhC6IutBmTP6aQCEMWtKAb6jkgEbSy3MIl/xzEAVFgk+BP/rWYjoGX3xgot6LhVEuZNe3aZDpLvwvdURUVwDwN6ABMBhYNW9u1Vmphk4r6qAD9HUuKltozBjX90q04G9VwGG9bkAqebnOvSrBwW3iXgEXQcMiQ9id2BvT7zfWFOUgelOlEfPwxQy+wnElx8NsP1RXXaOdp4ZgH6SzLOrh/2Lb6nKGn4s/d1G3yNLr+9GiOF3IySxiBZB6D17OPFFWm3ZmyoH3tpE5SkH1PAQRBYf3S+dKvbmE/8uvICvzoCcIvXU+O7W45sZIz9aloNERTG0hRxEfRAqLuMQG/WeQ5rLyJJzG2AUXe0AScO2KJD85xEdVM+JR0n6qCvfWkOmZkIQ==",
           p_key: "invalid-key",
@@ -136,6 +141,7 @@ describe("POST /api/otc_trades", () => {
       new Request(`${TEST_BASE_URL}/api/otc_trades`, {
         method: "POST",
         body: JSON.stringify({
+          trade_id: "09e02623-d6b7-59be-ae65-0f562986ea14",
           encrypted_payload:
             "DMlO/ObmxvFplP8Xm6k7g5V0XFZd8PfAzJdX5hgBupHYW3odASMe/B/v2+zQdQw9Tu2cADi9H0oUfbK4gGHD79ik0WlIpAkQlJXPHkloqF8xLAVJZkn9i4KduNOKTIDGA58rEcN8v+dZd1kYiKAyH9t4fpzTsxYcI0bJNQIOvVwE4K/TB7MHw/nnbkiNvVWSuwVroQJ0Hw5eNQxfKfmhC6IutBmTP6aQCEMWtKAb6jkgEbSy3MIl/xzEAVFgk+BP/rWYjoGX3xgot6LhVEuZNe3aZDpLvwvdURUVwDwN6ABMBhYNW9u1Vmphk4r6qAD9HUuKltozBjX90q04G9VwGG9bkAqebnOvSrBwW3iXgEXQcMiQ9id2BvT7zfWFOUgelOlEfPwxQy+wnElx8NsP1RXXaOdp4ZgH6SzLOrh/2Lb6nKGn4s/d1G3yNLr+9GiOF3IySxiBZB6D17OPFFWm3ZmyoH3tpE5SkH1PAQRBYf3S+dKvbmE/8uvICvzoCcIvXU+O7W45sZIz9aloNERTG0hRxEfRAqLuMQG/WeQ5rLyJJzG2AUXe0AScO2KJD85xEdVM+JR0n6qCvfWkOmZkIQ==",
           iv: "e9QTDukeRo97zGVZ",

--- a/src/app/api/otc_trades/route.test.ts
+++ b/src/app/api/otc_trades/route.test.ts
@@ -1,3 +1,4 @@
+import { base64urlnopad } from "@scure/base"
 import { supabase } from "@src/libs/supabase"
 import { TEST_BASE_URL } from "@src/tests/setup"
 import { logger } from "@src/utils/logger"
@@ -7,7 +8,7 @@ import { POST } from "./route"
 vi.mock("@src/libs/supabase", () => ({
   supabase: {
     from: vi.fn(() => ({
-      upsert: vi.fn(),
+      insert: vi.fn(),
     })),
   },
 }))
@@ -21,14 +22,12 @@ describe("POST /api/otc_trades", () => {
     vi.clearAllMocks()
   })
 
-  it("should create otc trade successfully", async () => {
-    const mockUpsert = vi.fn().mockResolvedValue({
+  it("should create otc trade successfully with iv", async () => {
+    const mockInsert = vi.fn().mockResolvedValue({
       error: null,
-      data: { trade_id: "84b1d4b5-f9df-4d12-8706-72bd67bad634" },
     })
-    const mockSelect = vi.fn().mockReturnValue({ single: () => mockUpsert() })
     vi.mocked(supabase.from).mockReturnValue({
-      upsert: () => ({ select: mockSelect }),
+      insert: mockInsert,
     })
 
     const response = await POST(
@@ -42,10 +41,34 @@ describe("POST /api/otc_trades", () => {
       })
     )
 
-    expect(response.status).toBe(200)
+    expect(response.status).toBe(201)
     await expect(response.json()).resolves.toEqual({
       success: true,
-      trade_id: "84b1d4b5-f9df-4d12-8706-72bd67bad634",
+    })
+  })
+
+  it("should create otc trade successfully with p_key", async () => {
+    const mockInsert = vi.fn().mockResolvedValue({
+      error: null,
+    })
+    vi.mocked(supabase.from).mockReturnValue({
+      insert: mockInsert,
+    })
+
+    const response = await POST(
+      new Request(`${TEST_BASE_URL}/api/otc_trades`, {
+        method: "POST",
+        body: JSON.stringify({
+          encrypted_payload:
+            "DMlO/ObmxvFplP8Xm6k7g5V0XFZd8PfAzJdX5hgBupHYW3odASMe/B/v2+zQdQw9Tu2cADi9H0oUfbK4gGHD79ik0WlIpAkQlJXPHkloqF8xLAVJZkn9i4KduNOKTIDGA58rEcN8v+dZd1kYiKAyH9t4fpzTsxYcI0bJNQIOvVwE4K/TB7MHw/nnbkiNvVWSuwVroQJ0Hw5eNQxfKfmhC6IutBmTP6aQCEMWtKAb6jkgEbSy3MIl/xzEAVFgk+BP/rWYjoGX3xgot6LhVEuZNe3aZDpLvwvdURUVwDwN6ABMBhYNW9u1Vmphk4r6qAD9HUuKltozBjX90q04G9VwGG9bkAqebnOvSrBwW3iXgEXQcMiQ9id2BvT7zfWFOUgelOlEfPwxQy+wnElx8NsP1RXXaOdp4ZgH6SzLOrh/2Lb6nKGn4s/d1G3yNLr+9GiOF3IySxiBZB6D17OPFFWm3ZmyoH3tpE5SkH1PAQRBYf3S+dKvbmE/8uvICvzoCcIvXU+O7W45sZIz9aloNERTG0hRxEfRAqLuMQG/WeQ5rLyJJzG2AUXe0AScO2KJD85xEdVM+JR0n6qCvfWkOmZkIQ==",
+          p_key: "oNn2ERFTt5qfeqHeY8zKsO5CxfECNl8AhWvdRdD38sw",
+        }),
+      })
+    )
+
+    expect(response.status).toBe(201)
+    await expect(response.json()).resolves.toEqual({
+      success: true,
     })
   })
 
@@ -66,12 +89,11 @@ describe("POST /api/otc_trades", () => {
   })
 
   it("should return 500 when database insert fails", async () => {
-    const mockUpsert = vi.fn().mockResolvedValue({
+    const mockInsert = vi.fn().mockResolvedValue({
       error: new Error("DB error"),
     })
-    const mockSelect = vi.fn().mockReturnValue({ single: () => mockUpsert() })
     vi.mocked(supabase.from).mockReturnValue({
-      upsert: () => ({ select: mockSelect }),
+      insert: mockInsert,
     })
 
     const response = await POST(
@@ -90,5 +112,40 @@ describe("POST /api/otc_trades", () => {
       error: "Failed to create otc trade",
     })
     expect(logger.error).toHaveBeenCalledOnce()
+  })
+
+  it("should return 400 for invalid p_key data", async () => {
+    const response = await POST(
+      new Request(`${TEST_BASE_URL}/api/otc_trades`, {
+        method: "POST",
+        body: JSON.stringify({
+          encrypted_payload:
+            "DMlO/ObmxvFplP8Xm6k7g5V0XFZd8PfAzJdX5hgBupHYW3odASMe/B/v2+zQdQw9Tu2cADi9H0oUfbK4gGHD79ik0WlIpAkQlJXPHkloqF8xLAVJZkn9i4KduNOKTIDGA58rEcN8v+dZd1kYiKAyH9t4fpzTsxYcI0bJNQIOvVwE4K/TB7MHw/nnbkiNvVWSuwVroQJ0Hw5eNQxfKfmhC6IutBmTP6aQCEMWtKAb6jkgEbSy3MIl/xzEAVFgk+BP/rWYjoGX3xgot6LhVEuZNe3aZDpLvwvdURUVwDwN6ABMBhYNW9u1Vmphk4r6qAD9HUuKltozBjX90q04G9VwGG9bkAqebnOvSrBwW3iXgEXQcMiQ9id2BvT7zfWFOUgelOlEfPwxQy+wnElx8NsP1RXXaOdp4ZgH6SzLOrh/2Lb6nKGn4s/d1G3yNLr+9GiOF3IySxiBZB6D17OPFFWm3ZmyoH3tpE5SkH1PAQRBYf3S+dKvbmE/8uvICvzoCcIvXU+O7W45sZIz9aloNERTG0hRxEfRAqLuMQG/WeQ5rLyJJzG2AUXe0AScO2KJD85xEdVM+JR0n6qCvfWkOmZkIQ==",
+          p_key: "invalid-key",
+        }),
+      })
+    )
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toBeDefined()
+  })
+
+  it("should return 400 when both iv and p_key are provided", async () => {
+    const response = await POST(
+      new Request(`${TEST_BASE_URL}/api/otc_trades`, {
+        method: "POST",
+        body: JSON.stringify({
+          encrypted_payload:
+            "DMlO/ObmxvFplP8Xm6k7g5V0XFZd8PfAzJdX5hgBupHYW3odASMe/B/v2+zQdQw9Tu2cADi9H0oUfbK4gGHD79ik0WlIpAkQlJXPHkloqF8xLAVJZkn9i4KduNOKTIDGA58rEcN8v+dZd1kYiKAyH9t4fpzTsxYcI0bJNQIOvVwE4K/TB7MHw/nnbkiNvVWSuwVroQJ0Hw5eNQxfKfmhC6IutBmTP6aQCEMWtKAb6jkgEbSy3MIl/xzEAVFgk+BP/rWYjoGX3xgot6LhVEuZNe3aZDpLvwvdURUVwDwN6ABMBhYNW9u1Vmphk4r6qAD9HUuKltozBjX90q04G9VwGG9bkAqebnOvSrBwW3iXgEXQcMiQ9id2BvT7zfWFOUgelOlEfPwxQy+wnElx8NsP1RXXaOdp4ZgH6SzLOrh/2Lb6nKGn4s/d1G3yNLr+9GiOF3IySxiBZB6D17OPFFWm3ZmyoH3tpE5SkH1PAQRBYf3S+dKvbmE/8uvICvzoCcIvXU+O7W45sZIz9aloNERTG0hRxEfRAqLuMQG/WeQ5rLyJJzG2AUXe0AScO2KJD85xEdVM+JR0n6qCvfWkOmZkIQ==",
+          iv: "e9QTDukeRo97zGVZ",
+          p_key: "oNn2ERFTt5qfeqHeY8zKsO5CxfECNl8AhWvdRdD38sw",
+        }),
+      })
+    )
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toBeDefined()
   })
 })

--- a/src/app/api/otc_trades/route.ts
+++ b/src/app/api/otc_trades/route.ts
@@ -1,51 +1,68 @@
 import { base64 } from "@scure/base"
+import { base64urlnopad } from "@scure/base"
 import type {
   CreateOtcTradeRequest,
   CreateOtcTradeResponse,
   ErrorResponse,
-  OtcTrade,
 } from "@src/features/otc/types/otcTypes"
 import { supabase } from "@src/libs/supabase"
 import { logger } from "@src/utils/logger"
 import { NextResponse } from "next/server"
 import { z } from "zod"
 
-const otcTradesSchema: z.ZodType<CreateOtcTradeRequest> = z.object({
-  encrypted_payload: z.string().refine((val) => {
-    try {
-      const decoded = base64.decode(val)
-      // AES-GCM produces variable length output, but should be at least 16 bytes
-      return decoded.length >= 16
-    } catch (err) {
-      return false
-    }
-  }, "Invalid encrypted_payload format"),
-  iv: z.string().refine((val) => {
-    try {
-      const decoded = base64.decode(val)
-      // IV should be exactly 12 bytes for AES-GCM
-      return decoded.length === 12
-    } catch (err) {
-      return false
-    }
-  }, "Invalid IV format"),
-})
+const otcTradesSchema = z
+  .object({
+    encrypted_payload: z.string().refine((val) => {
+      try {
+        const decoded = base64.decode(val)
+        // AES-GCM produces variable length output, but should be at least 16 bytes
+        return decoded.length >= 16
+      } catch (err) {
+        return false
+      }
+    }, "Invalid encrypted_payload format"),
+  })
+  .and(
+    z.union([
+      z.object({
+        iv: z.string().refine((val) => {
+          try {
+            const decoded = base64.decode(val)
+            // IV should be exactly 12 bytes for AES-GCM
+            return decoded.length === 12
+          } catch (err) {
+            return false
+          }
+        }, "Invalid IV format"),
+        p_key: z.never().optional(),
+      }),
+      z.object({
+        p_key: z.string().refine((val) => {
+          try {
+            const keyBytes = base64urlnopad.decode(val)
+            return keyBytes.length === 32
+          } catch {
+            return false
+          }
+        }, "Key must be exactly 32 bytes (AES-256)"),
+        iv: z.never().optional(),
+      }),
+    ])
+  ) as z.ZodType<CreateOtcTradeRequest>
 
 export async function POST(request: Request) {
   try {
     const body = await request.json()
     const validatedData = otcTradesSchema.parse(body)
 
-    const { data, error } = await supabase
-      .from("otc_trades")
-      .upsert([
-        {
-          encrypted_payload: validatedData.encrypted_payload,
-          iv: validatedData.iv,
-        },
-      ])
-      .select("trade_id")
-      .single()
+    const { error } = await supabase.from("otc_trades").insert([
+      {
+        encrypted_payload: validatedData.encrypted_payload,
+        ...("iv" in validatedData
+          ? { iv: validatedData.iv }
+          : { p_key: validatedData.p_key }),
+      },
+    ])
 
     if (error) {
       logger.error(error)
@@ -57,20 +74,12 @@ export async function POST(request: Request) {
       )
     }
 
-    if (!data) {
-      return NextResponse.json(
-        { error: "Failed to retrieve otc trade data" } satisfies ErrorResponse,
-        { status: 500 }
-      )
-    }
-
     return NextResponse.json(
       {
         success: true,
-        trade_id: data.trade_id,
       } satisfies CreateOtcTradeResponse,
       {
-        status: 200,
+        status: 201,
       }
     )
   } catch (error) {

--- a/src/app/api/otc_trades/route.ts
+++ b/src/app/api/otc_trades/route.ts
@@ -12,6 +12,13 @@ import { z } from "zod"
 
 const otcTradesSchema = z
   .object({
+    trade_id: z
+      .string()
+      .uuid()
+      .refine((val) => {
+        // UUID v5 has version bits set to 5 (0101)
+        return val[14] === "5"
+      }, "Invalid trade_id format"),
     encrypted_payload: z.string().refine((val) => {
       try {
         const decoded = base64.decode(val)
@@ -57,6 +64,7 @@ export async function POST(request: Request) {
 
     const { error } = await supabase.from("otc_trades").insert([
       {
+        trade_id: validatedData.trade_id,
         encrypted_payload: validatedData.encrypted_payload,
         ...("iv" in validatedData
           ? { iv: validatedData.iv }

--- a/src/app/otc-desk/_utils/encoder.ts
+++ b/src/app/otc-desk/_utils/encoder.ts
@@ -1,4 +1,5 @@
 import { base64, base64urlnopad } from "@scure/base"
+import { v5 as uuidv5 } from "uuid"
 
 export function encodeOrder(order: unknown): string {
   const format = {
@@ -110,4 +111,8 @@ function validateKey(pKey: string): void {
   } catch {
     throw new Error("Key must be exactly 32 bytes (AES-256)")
   }
+}
+
+export function deriveTradeIdFromIV(iv: string): string {
+  return uuidv5(iv, "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 }

--- a/src/app/otc-desk/_utils/link.ts
+++ b/src/app/otc-desk/_utils/link.ts
@@ -73,9 +73,12 @@ export function useOtcOrder() {
         const trade = await getTrade(decodeOrder(order))
         if (trade) {
           try {
-            const { encrypted_payload, iv, pKey } = trade
+            const { encryptedPayload, iv, pKey } = trade
+            if (!iv || !pKey) {
+              throw new Error("Invalid decoded params")
+            }
             const decrypted = await decodeAES256Order(
-              encrypted_payload,
+              encryptedPayload,
               pKey,
               iv
             )

--- a/src/app/otc-desk/_utils/link.ts
+++ b/src/app/otc-desk/_utils/link.ts
@@ -2,6 +2,7 @@ import { base64 } from "@scure/base"
 import {
   decodeAES256Order,
   decodeOrder,
+  deriveTradeIdFromIV,
   encodeAES256Order,
   encodeOrder,
 } from "@src/app/otc-desk/_utils/encoder"
@@ -42,10 +43,12 @@ export async function createOtcOrder(payload: unknown): Promise<{
     // Generate client-side IV and pKey for the order
     const iv = crypto.getRandomValues(new Uint8Array(12))
     const pKey = await genPKey()
+    const tradeId = deriveTradeIdFromIV(base64.encode(iv))
 
     const encrypted = await encodeAES256Order(payload, pKey, iv)
 
     const result = await saveTrade({
+      trade_id: tradeId,
       encrypted_payload: encrypted,
       iv: base64.encode(iv),
     })
@@ -53,7 +56,7 @@ export async function createOtcOrder(payload: unknown): Promise<{
       throw new Error("Failed to save trade")
     }
     return {
-      tradeId: result.trade_id,
+      tradeId,
       pKey,
     }
   } catch (e) {
@@ -70,9 +73,9 @@ export function useOtcOrder() {
     queryFn: async () => {
       // 1. Attempt: Try to fetch and decrypt the order from the database
       if (order) {
-        const trade = await getTrade(decodeOrder(order))
-        if (trade) {
-          try {
+        try {
+          const trade = await getTrade(decodeOrder(order))
+          if (trade) {
             const { encryptedPayload, iv, pKey } = trade
             if (!iv || !pKey) {
               throw new Error("Invalid decoded params")
@@ -86,13 +89,9 @@ export function useOtcOrder() {
               tradeId: trade.tradeId,
               multiPayload: decrypted,
             }
-          } catch (error) {
-            logger.error("Failed to decrypt order")
-            return {
-              tradeId: null,
-              multiPayload: "",
-            }
           }
+        } catch (error) {
+          logger.error("Failed to decrypt order")
         }
       }
 
@@ -105,11 +104,7 @@ export function useOtcOrder() {
             multiPayload: decoded,
           }
         } catch (error) {
-          logger.error("Failed to decode order")
-          return {
-            tradeId: null,
-            multiPayload: "",
-          }
+          logger.error("Failed to decode legacy order")
         }
       }
 

--- a/src/features/otc/lib/otcService.ts
+++ b/src/features/otc/lib/otcService.ts
@@ -1,4 +1,5 @@
 import { base64urlnopad } from "@scure/base"
+import { deriveTradeIdFromIV } from "@src/app/otc-desk/_utils/encoder"
 import type {
   CreateOtcTradeRequest,
   CreateOtcTradeResponse,
@@ -12,13 +13,20 @@ export async function getTrade(
   if (!params) {
     return null
   }
-  const { tradeId, pKey } = deriveTradeParams(params)
-  const response = await getOTCTrade(tradeId)
+  const { tradeId, pKey, iv } = deriveTradeParams(params)
+
+  // Get trade ID either directly or derive it from IV
+  const resolvedTradeId = tradeId || (iv ? deriveTradeIdFromIV(iv) : null)
+  if (!resolvedTradeId) {
+    throw new Error("Invalid trade params")
+  }
+
+  const response = await getOTCTrade(resolvedTradeId)
   return {
-    tradeId,
-    encrypted_payload: response.encrypted_payload,
-    iv: response.iv,
-    pKey: pKey,
+    tradeId: resolvedTradeId,
+    encryptedPayload: response.encrypted_payload,
+    iv: iv ?? response.iv,
+    pKey: pKey ?? response.p_key,
   }
 }
 
@@ -27,7 +35,7 @@ export async function saveTrade(
 ): Promise<CreateOtcTradeResponse> {
   const response = await createOTCTrade({
     encrypted_payload: trade.encrypted_payload,
-    iv: trade.iv,
+    ...("iv" in trade ? { iv: trade.iv } : { pKey: trade.pKey }),
   })
   if (!response.success) {
     throw new Error("Failed to save credential")
@@ -38,9 +46,18 @@ export async function saveTrade(
   }
 }
 
-function deriveTradeParams(params: string) {
+function deriveTradeParams(params: string): {
+  tradeId: string | null
+  pKey: string | null
+  iv: string | null
+} {
+  // v1: tradeId#pKey
   const [tradeId, pKey] = params.split("#")
-  return { tradeId, pKey }
+  if (tradeId && pKey) {
+    return { tradeId, pKey, iv: null }
+  }
+  // v2: iv
+  return { iv: params, tradeId: null, pKey: null }
 }
 
 // Key for AES-256-GCM must be 32-bytes and URL safe

--- a/src/features/otc/lib/otcService.ts
+++ b/src/features/otc/lib/otcService.ts
@@ -34,15 +34,15 @@ export async function saveTrade(
   trade: CreateOtcTradeRequest
 ): Promise<CreateOtcTradeResponse> {
   const response = await createOTCTrade({
+    trade_id: trade.trade_id,
     encrypted_payload: trade.encrypted_payload,
-    ...("iv" in trade ? { iv: trade.iv } : { pKey: trade.pKey }),
+    ...("iv" in trade ? { iv: trade.iv } : { p_key: trade.p_key }),
   })
   if (!response.success) {
     throw new Error("Failed to save credential")
   }
   return {
     success: response.success,
-    trade_id: response.trade_id,
   }
 }
 

--- a/src/features/otc/types/otcTypes.ts
+++ b/src/features/otc/types/otcTypes.ts
@@ -6,6 +6,7 @@ export interface OtcTrade {
 }
 
 export type CreateOtcTradeRequest = {
+  trade_id: string
   encrypted_payload: string
 } & ({ iv: string } | { p_key: string })
 

--- a/src/features/otc/types/otcTypes.ts
+++ b/src/features/otc/types/otcTypes.ts
@@ -1,20 +1,22 @@
 export interface OtcTrade {
   tradeId: string
-  encrypted_payload: string
-  iv: string
-  pKey: string
+  encryptedPayload: string
+  iv: string | null
+  pKey: string | null
 }
 
-export type CreateOtcTradeRequest = Omit<OtcTrade, "pKey" | "tradeId">
+export type CreateOtcTradeRequest = {
+  encrypted_payload: string
+} & ({ iv: string } | { p_key: string })
 
 export interface CreateOtcTradeResponse {
   success: boolean
-  trade_id: string
 }
 
 export interface GetOtcTradeResponse {
   encrypted_payload: string
-  iv: string
+  iv: string | null
+  p_key: string | null
 }
 
 export interface ErrorResponse {


### PR DESCRIPTION
These changes don’t interfere with the current logic and prepare for using only IV in the generated links.

Depends on #430 