### PR TITLE
Use receipt_index_in_block as txnIndex

### DIFF
--- a/src/app/api/integrations/dextools/asset/holders/route.ts
+++ b/src/app/api/integrations/dextools/asset/holders/route.ts
@@ -7,7 +7,11 @@ import { isErr, ok, tryCatch } from "../../../shared/result"
 import type { ApiResult } from "../../../shared/types"
 import { validateQueryParams } from "../../../shared/utils"
 
-const querySchema = z.object({ id: z.string() })
+const querySchema = z.object({
+  id: z.string(),
+  page: z.coerce.number().optional(),
+  pageSize: z.coerce.number().optional(),
+})
 
 /**
  * Returns a paginated list of the largest token holders.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for optional pagination parameters when retrieving asset holder data.

- **Improvements**
  - Enhanced event data to include transaction index information for more precise sorting and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->