### PR TITLE
chore: bump defuse-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@clickhouse/client": "^1.11.2",
-    "@defuse-protocol/defuse-sdk": "^1.0.0-beta.175",
+    "@defuse-protocol/defuse-sdk": "^1.0.0-beta.177",
     "@near-eth/aurora-erc20": "^2.8.0",
     "@near-eth/aurora-ether": "^3.0.0",
     "@near-eth/aurora-nep141": "^1.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,10 +1079,10 @@
   resolved "https://registry.yarnpkg.com/@defuse-protocol/contract-types/-/contract-types-0.0.2.tgz#921acf85081123826809273635c08d6be9b6b033"
   integrity sha512-BRcyQrhVuY6kAmUg/fxqMr1zAdsijN3Neeo8uZqKKvBNe4mnoM07rTQLtC5LKqZpIUobhH2bsbzvbqjAM3zJ9w==
 
-"@defuse-protocol/defuse-sdk@^1.0.0-beta.175":
-  version "1.0.0-beta.175"
-  resolved "https://registry.yarnpkg.com/@defuse-protocol/defuse-sdk/-/defuse-sdk-1.0.0-beta.175.tgz#5dd38391a8202b4e0dd24851b836fc5fcc452033"
-  integrity sha512-tpVwjefkZpld3I10SGzBmUbB4/DjIx86fHTncm/WiEbk90E+YDjd03/h+7T2NiqCZSoAxz2qe2saWYsuJlARxw==
+"@defuse-protocol/defuse-sdk@^1.0.0-beta.177":
+  version "1.0.0-beta.177"
+  resolved "https://registry.yarnpkg.com/@defuse-protocol/defuse-sdk/-/defuse-sdk-1.0.0-beta.177.tgz#0394ae847ad3b2e8429dd214837d334fee9eaabb"
+  integrity sha512-vvsElgJFQtCPiGIBXmyKwHIieojrrfA08JqAObRQbnJM9yh43SvgS/rOfcKSq+9r3roWoLf5tdr39oSoOMg+Xw==
   dependencies:
     "@defuse-protocol/bridge-sdk" "^0.3.0"
     "@lifeomic/attempt" "^3.1.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the "@defuse-protocol/defuse-sdk" dependency to a newer version for improved stability and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->