### PR TITLE
feat: update CSP to include intents-near.org subdomains

### DIFF
--- a/src/config/csp.ts
+++ b/src/config/csp.ts
@@ -41,8 +41,7 @@ const cspConfig = {
     "https://api-js.mixpanel.com",
 
     /** Stage Solver Relay and Bridge Services */
-    "http://35.242.147.168",
-    "http://34.105.197.59",
+    "https://*.intents-near.org",
 
     /** Helpscout */
     "https://beaconapi.helpscout.net",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security settings to allow connections to any secure subdomain of "intents-near.org" and removed support for specific HTTP IP addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->