### PR TITLE
chore: show last 4 digits of token contract in deposit warning hint

### DIFF
--- a/src/components/DefuseSDK/features/deposit/components/DepositForm/renderDepositHint.tsx
+++ b/src/components/DefuseSDK/features/deposit/components/DepositForm/renderDepositHint.tsx
@@ -1,6 +1,7 @@
 import type { BlockchainEnum } from "@defuse-protocol/internal-utils"
 import { Callout } from "@radix-ui/themes"
 import { reverseAssetNetworkAdapter } from "@src/components/DefuseSDK/utils/adapters"
+import { isFungibleToken } from "@src/components/DefuseSDK/utils/token"
 import type { BaseTokenInfo } from "../../../../types/base"
 import { formatTokenValue } from "../../../../utils/format"
 
@@ -14,7 +15,8 @@ export function renderDepositHint(
         <Callout.Text className="text-xs">
           <span className="font-bold">
             {/* biome-ignore lint/nursery/useConsistentCurlyBraces: <explanation> */}
-            Only deposit {token.symbol} from the{" "}
+            Only deposit {token.symbol}
+            {formatShortenedContractAddress(token)} from the{" "}
             {reverseAssetNetworkAdapter[network]} network.
             {/* biome-ignore lint/nursery/useConsistentCurlyBraces: <explanation> */}
           </span>{" "}
@@ -43,3 +45,6 @@ export function renderMinDepositAmountHint(
     </div>
   )
 }
+
+const formatShortenedContractAddress = (token: BaseTokenInfo): string =>
+  isFungibleToken(token) ? `(...${token.address.slice(-4)})` : ""


### PR DESCRIPTION
Small UX improvement: include partial token address in deposit hint.

<details>
<summary>Example:</summary>
<img width="458" height="65" alt="Screenshot 2025-08-08 at 11 28 03" src="https://github.com/user-attachments/assets/efee1ebc-3cdc-49f2-b2f9-0c3849fa540d" />

</details>