### PR TITLE
chore: remove trustline check in Stellar active deposit operation

### DIFF
--- a/src/components/DefuseSDK/features/deposit/components/DepositUIMachineProvider.tsx
+++ b/src/components/DefuseSDK/features/deposit/components/DepositUIMachineProvider.tsx
@@ -474,8 +474,6 @@ export function DepositUIMachineProvider({
                   depositAddress,
                   amount,
                   token: derivedToken,
-                  // TODO: check if trustline exists
-                  trustlineExists: true,
                   memo,
                 })
 

--- a/src/components/DefuseSDK/services/depositService.ts
+++ b/src/components/DefuseSDK/services/depositService.ts
@@ -681,14 +681,12 @@ export async function createDepositStellarTransaction({
   depositAddress,
   amount,
   token,
-  trustlineExists,
   memo,
 }: {
   userAddress: string
   depositAddress: string
   amount: bigint
   token: BaseTokenInfo
-  trustlineExists: boolean
   memo?: string | null
 }): Promise<SendTransactionStellarParams> {
   assert(token.chainName === "stellar", "Token must be a Stellar token")
@@ -712,7 +710,6 @@ export async function createDepositStellarTransaction({
     amountToFormat,
     token.address,
     token.symbol,
-    trustlineExists,
     memo
   )
 }
@@ -749,7 +746,6 @@ function createTrustlineTransferStellarTransaction(
   amount: string,
   tokenAddress: string,
   tokenSymbol: string,
-  trustlineExists: boolean,
   memo?: string | null
 ): SendTransactionStellarParams {
   const asset = new Asset(tokenSymbol, tokenAddress)
@@ -757,16 +753,6 @@ function createTrustlineTransferStellarTransaction(
     fee: "100", // TODO: Should be checked
     networkPassphrase: Networks.PUBLIC,
   })
-
-  // TODO: Revisit this once trustlineExists is implemented
-  if (!trustlineExists) {
-    transaction.addOperation(
-      Operation.changeTrust({
-        asset: asset,
-        limit: "922337203685.4775807", // max trustline limit
-      })
-    )
-  }
 
   transaction.addOperation(
     Operation.payment({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Stellar deposit flow for tokens by removing automatic trustline setup.
  * Deposits now proceed directly with asset transfer; wallets must have the required trustline pre-configured.
  * Reduces extra steps during deposit and may speed up successful transfers when the trustline already exists.
  * If a trustline is missing, deposits may fail until the wallet is configured accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->