### PR TITLE
chore: update intents-sdk to v0.17.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "dependencies": {
         "@clickhouse/client": "^1.11.2",
         "@creit.tech/stellar-wallets-kit": "^1.8.0",
-        "@defuse-protocol/intents-sdk": "0.16.4",
+        "@defuse-protocol/intents-sdk": "0.17.0",
         "@defuse-protocol/internal-utils": "0.8.2",
         "@lifeomic/attempt": "^3.1.0",
         "@near-eth/aurora-erc20": "^2.8.0",
@@ -526,7 +526,7 @@
 
     "@defuse-protocol/contract-types": ["@defuse-protocol/contract-types@0.0.3", "", {}, "sha512-N3LJS4tfshw6+kldrx6Hij8c8tzTHbmNPVByhursQ86Apu8p/gOPixfBbUZh21fKCCqktERbjeKzGe5EJV0gWA=="],
 
-    "@defuse-protocol/intents-sdk": ["@defuse-protocol/intents-sdk@0.16.4", "", { "dependencies": { "@defuse-protocol/contract-types": "0.0.3", "@defuse-protocol/internal-utils": "0.8.2", "@hot-labs/omni-sdk": "2.16.0", "@isaacs/ttlcache": "^1.0.0", "@lifeomic/attempt": "^3.0.0", "@near-js/accounts": "^2.0.1", "@near-js/client": "^2.0.1", "@near-js/keystores": "^2.0.1", "@scure/base": "^1.0.0", "borsher": "^4.0.0", "near-api-js": "^4.0.0 || ^5.0.0", "omni-bridge-sdk": "0.13.1", "viem": "^2.0.0" }, "peerDependencies": { "typescript": "^5" } }, "sha512-e0IPwkmcxqkYitVtQVJMsxhs3CQQus1DJgQA/23ippOJDR+OvelDdng/yPNpIVmiVzuqBkt8JZbxmhSFxu8ybg=="],
+    "@defuse-protocol/intents-sdk": ["@defuse-protocol/intents-sdk@0.17.0", "", { "dependencies": { "@defuse-protocol/contract-types": "0.0.3", "@defuse-protocol/internal-utils": "0.8.2", "@hot-labs/omni-sdk": "2.16.0", "@isaacs/ttlcache": "^1.0.0", "@lifeomic/attempt": "^3.0.0", "@near-js/accounts": "^2.0.1", "@near-js/client": "^2.0.1", "@near-js/keystores": "^2.0.1", "@scure/base": "^1.0.0", "borsher": "^4.0.0", "near-api-js": "^4.0.0 || ^5.0.0", "omni-bridge-sdk": "0.13.1", "viem": "^2.0.0" }, "peerDependencies": { "typescript": "^5" } }, "sha512-GgJQ9SGdzFRLLzLCo3KAY0t0Mcw+O+TrZPUwYVhhkv9UHesUwK19aTj4GBfJSwLK87EDnG/Ha+nISrj2zXVLDA=="],
 
     "@defuse-protocol/internal-utils": ["@defuse-protocol/internal-utils@0.8.2", "", { "dependencies": { "@defuse-protocol/contract-types": "0.0.3", "@lifeomic/attempt": "^3.0.0", "@noble/hashes": "^1.7.1", "@peculiar/asn1-ecc": "^2.0.0", "@peculiar/asn1-schema": "^2.0.0", "@scure/base": "^1.0.0", "@thames/monads": "^0.7.0", "near-api-js": "^4.0.0 || ^5.0.0", "tweetnacl": "^1.0.0", "valibot": "^1.0.0", "viem": "^2.0.0" } }, "sha512-Q/++nslkO1nDVgQoLXoy6Xb4ECCT23B4CCC6V/PakDR8GrIEWJ54aX9udVl+IC9imiYwFIXzLyHbeUG538BZYg=="],
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@clickhouse/client": "^1.11.2",
     "@creit.tech/stellar-wallets-kit": "^1.8.0",
-    "@defuse-protocol/intents-sdk": "0.16.4",
+    "@defuse-protocol/intents-sdk": "0.17.0",
     "@defuse-protocol/internal-utils": "0.8.2",
     "@lifeomic/attempt": "^3.1.0",
     "@near-eth/aurora-erc20": "^2.8.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded underlying @defuse-protocol/intents-sdk dependency from 0.16.4 to 0.17.0 to keep the app current with the latest SDK release. This brings upstream improvements and fixes and ensures continued compatibility with the ecosystem. No changes to the public interface or user workflows are expected. No action required from users. Performance or behavior should remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->