### PR TITLE
feat: make Tron wallet public

### DIFF
--- a/src/components/Wallet/index.tsx
+++ b/src/components/Wallet/index.tsx
@@ -13,7 +13,6 @@ import { FeatureFlagsContext } from "@src/providers/FeatureFlagsProvider"
 import { useSignInWindowOpenState } from "@src/stores/useSignInWindowOpenState"
 import { mapStringToEmojis } from "@src/utils/emoji"
 import { TURN_OFF_APPS } from "@src/utils/environment"
-import { useSearchParams } from "next/navigation"
 import { TonConnectButton } from "./TonConnectButton"
 
 const ConnectWallet = () => {
@@ -21,7 +20,6 @@ const ConnectWallet = () => {
   const { state, signIn, connectors } = useConnectWallet()
   const { shortAccountId } = useShortAccountId(state.displayAddress ?? "")
   const { whitelabelTemplate } = useContext(FeatureFlagsContext)
-  const searchParams = useSearchParams()
 
   const handleNearWalletSelector = () => {
     return signIn({ id: ChainType.Near })
@@ -297,29 +295,26 @@ const ConnectWallet = () => {
                     </Button>
 
                     {/* Tron connector */}
-                    {/* TODO: Remove searchParams check once Tron is fully supported */}
-                    {searchParams.get("tron") && (
-                      <Button
-                        onClick={() => signIn({ id: ChainType.Tron })}
-                        size="4"
-                        radius="medium"
-                        variant="soft"
-                        color="gray"
-                        className="px-2.5"
-                      >
-                        <div className="w-full flex items-center justify-start gap-2">
-                          <Image
-                            src="/static/icons/network/tron.svg"
-                            alt="Tron"
-                            width={36}
-                            height={36}
-                          />
-                          <Text size="2" weight="bold">
-                            Tron Wallet
-                          </Text>
-                        </div>
-                      </Button>
-                    )}
+                    <Button
+                      onClick={() => signIn({ id: ChainType.Tron })}
+                      size="4"
+                      radius="medium"
+                      variant="soft"
+                      color="gray"
+                      className="px-2.5"
+                    >
+                      <div className="w-full flex items-center justify-start gap-2">
+                        <Image
+                          src="/static/icons/network/tron.svg"
+                          alt="Tron"
+                          width={36}
+                          height={36}
+                        />
+                        <Text size="2" weight="bold">
+                          Tron Wallet
+                        </Text>
+                      </div>
+                    </Button>
 
                     <Text size="1" color="gray">
                       Other options


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tron Wallet option is now available by default in the wallet selector across both TurboSwap and standard experiences. Users no longer need any special conditions to see or use the Tron Wallet.
  * No changes to other wallet options; their behavior and availability remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->