### PR TITLE
fix: sign in modal

### DIFF
--- a/src/components/Wallet/index.tsx
+++ b/src/components/Wallet/index.tsx
@@ -56,6 +56,7 @@ const ConnectWallet = () => {
         <Popover.Content
           maxWidth={{ initial: "90vw", xs: "480px" }}
           minWidth={{ initial: "300px", xs: "330px" }}
+          maxHeight="90vh"
           className="md:mr-[48px] dark:bg-black-800 rounded-2xl"
         >
           <Text size="1">How do you want to sign in?</Text>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the unauthenticated Connect Wallet popover to respect the viewport by limiting its height to 90% of the screen. This prevents content from overflowing off-screen and enhances readability and scrolling on smaller displays without altering any behaviors or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->