### PR TITLE
fix: remove intear-wallet workaround

### DIFF
--- a/src/providers/NearWalletProvider.tsx
+++ b/src/providers/NearWalletProvider.tsx
@@ -111,17 +111,6 @@ export const NearWalletProvider: FC<{ children: ReactNode }> = ({
       const wallet = await connector.wallet()
       const signatureData = await wallet.signMessage(message)
 
-      // TODO: This is a temporary workaround until Intear Wallet updates are included in @hot-labs/near-connect package to follow the standard signature format
-      // Intear Wallet returns base58 encoded signatures with `ed25519:` prefix, but we expect base64 encoded signatures
-      if (wallet.manifest.id === "intear-wallet") {
-        const rawSignature = base58.decode(
-          signatureData.signature.replace("ed25519:", "")
-        )
-        Object.assign(signatureData, {
-          signature: base64.encode(new Uint8Array(rawSignature)),
-        })
-      }
-
       return {
         signatureData,
         signedData: message,


### PR DESCRIPTION
The response format is now correct in intear wallet, so no workaround is needed. In fact, now this workaround prevents intear wallet users from using the app, as it expects the wrong format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Adjusted message signature handling for certain Near wallets to use the wallet-provided signature without additional transformation, improving reliability and compatibility across signing flows (e.g., sign-in and verification).

- Refactor
  - Removed wallet-specific signature normalization to streamline processing. No changes to public APIs or types, and existing integrations continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->