### PR TITLE
fix: stale data in deposit field

### DIFF
--- a/src/components/DefuseSDK/features/machines/depositUIMachine.ts
+++ b/src/components/DefuseSDK/features/machines/depositUIMachine.ts
@@ -100,6 +100,10 @@ export const depositUIMachine = setup({
       preparationOutput: (_, val: Context["preparationOutput"]) => val,
     }),
 
+    resetPreparationOutput: assign({
+      preparationOutput: null,
+    }),
+
     clearResults: assign({
       depositOutput: null,
     }),
@@ -380,6 +384,7 @@ export const depositUIMachine = setup({
             },
             {
               target: "idle",
+              actions: "resetPreparationOutput",
             },
           ],
           entry: ["clearPreparationOutput"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When resetting the deposit flow, previous preparation output is now cleared so starting over won't show stale or conflicting preparation details. This ensures the deposit UI returns to a clean state and prevents incorrect data carryover when users restart the process. No other user-facing behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->