### PR TITLE
chore: disable navigation breadcrumbs in Sentry

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -99,6 +99,7 @@ const nextConfig = {
 const sentryConfig = {
   org: "defuse-labs-ltd",
   project: "frontend",
+  authToken: process.env.SENTRY_AUTH_TOKEN,
   silent: true,
   widenClientFileUpload: true,
   hideSourceMaps: false,

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -25,6 +25,11 @@ Sentry.init({
   beforeSend: (event) => {
     return processNoLiquidityEvent(event)
   },
+  // Navigation breadcrumbs may include sensitive user data (e.g., hashes), so we block them.
+  // Otherwise, history URLs should be sanitized before being sent to Sentry.
+  beforeBreadcrumb(breadcrumb) {
+    return breadcrumb.category === "navigation" ? null : breadcrumb
+  },
 })
 
 function processNoLiquidityEvent(event: Sentry.ErrorEvent) {


### PR DESCRIPTION
Note: use authToken in stack frames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Configured error monitoring to include an authentication token from environment variables.
  - Added a client-side filter to exclude navigation breadcrumbs from error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->