### PR TITLE
Update license notice to 2025 NEAR Foundation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Defuse
+Copyright (c) 2025 NEAR Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update the MIT license notice to reference 2025 NEAR Foundation

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_b_68cbd4d6fa4c832cb835687fc55691f6