### PR TITLE
Add 1click prefix to referral for 1click swaps

### DIFF
--- a/src/hooks/useIntentsReferral.ts
+++ b/src/hooks/useIntentsReferral.ts
@@ -1,6 +1,7 @@
 import type { WhitelabelTemplateValue } from "@src/config/featureFlags"
 import { FeatureFlagsContext } from "@src/providers/FeatureFlagsProvider"
 import { useContext } from "react"
+import { useIs1CsEnabled } from "./useIs1CsEnabled"
 
 export const referralMap: Record<WhitelabelTemplateValue, string> = {
   "near-intents": "near-intents.intents-referral.near",
@@ -12,5 +13,7 @@ export const referralMap: Record<WhitelabelTemplateValue, string> = {
 
 export function useIntentsReferral() {
   const { whitelabelTemplate } = useContext(FeatureFlagsContext)
-  return referralMap[whitelabelTemplate]
+  const is1cs = useIs1CsEnabled()
+  const referral = referralMap[whitelabelTemplate]
+  return is1cs ? `1click-${referral}` : referral
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Referral identifiers now automatically include a “1click-” prefix when 1‑click checkout is enabled, improving attribution clarity across the purchase flow. If 1‑click checkout isn’t enabled, referral identifiers remain unchanged. This ensures consistent tracking for campaigns and reporting without affecting existing behaviors for other users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->