### PR TITLE
fix: prevent crash app by division by zero in useSwapRateData

### DIFF
--- a/src/components/DefuseSDK/features/swap/hooks/useSwapRateData.ts
+++ b/src/components/DefuseSDK/features/swap/hooks/useSwapRateData.ts
@@ -37,7 +37,7 @@ function swapRateDataSelector(state: SnapshotFrom<typeof swapUIMachine>) {
 
   const amountIn = state.context.parsedFormValues.amountIn
   const exchangeRate =
-    amountIn != null
+    amountIn != null && amountOut.amount !== 0n // hotfix incorrect calculation when amountOut is 0
       ? {
           amount:
             (amountOut.amount * 10n ** BigInt(amountIn.decimals)) /
@@ -47,7 +47,7 @@ function swapRateDataSelector(state: SnapshotFrom<typeof swapUIMachine>) {
       : null
 
   const inverseExchangeRate =
-    amountIn != null
+    amountIn != null && amountOut.amount !== 0n // hotfix prevents division by zero when amountOut is 0
       ? {
           amount:
             (amountIn.amount * 10n ** BigInt(amountOut.decimals)) /


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents incorrect exchange rate and inverse rate calculations when the output amount is zero. Rates now correctly appear as unavailable instead of showing misleading values, avoiding division-by-zero scenarios and improving accuracy and stability in the swap UI. This results in clearer feedback during edge cases (e.g., insufficient liquidity or invalid amounts) without transient or erroneous rate displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->