### PR TITLE
fix: race condition in background1csQuoterMachine

### DIFF
--- a/src/components/DefuseSDK/features/machines/swapUIMachine.ts
+++ b/src/components/DefuseSDK/features/machines/swapUIMachine.ts
@@ -663,10 +663,10 @@ export const swapUIMachine = setup({
         input: {
           target: ".validating",
           actions: [
-            "clearQuote",
-            "updateUIAmountOut",
             "sendToBackgroundQuoterRefPause",
             "sendToBackground1csQuoterRefPause",
+            "clearQuote",
+            "updateUIAmountOut",
             "clearError",
             "clear1csError",
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures only the most recent quote is displayed, preventing stale results after pauses or rapid input changes.
  * Safely invalidates in-flight quote requests on pause/stop to avoid outdated updates.
  * Improves swap editing responsiveness by reordering UI updates, reducing flicker and incorrect amount outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->