### PR TITLE
fix: prevent hydration issue caused by TON connect

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,12 +1,25 @@
 "use client"
 
+import { Button, Text } from "@radix-ui/themes"
 import AddTurboChainButton from "@src/components/AddTurboChainButton"
 import Logo from "@src/components/Logo"
 import Settings from "@src/components/Settings"
-import ConnectWallet from "@src/components/Wallet"
 import { FeatureFlagsContext } from "@src/providers/FeatureFlagsProvider"
+import dynamic from "next/dynamic"
 import { type ReactNode, useContext } from "react"
 import styles from "./Header.module.css"
+
+// Prevent hydration mismatch by disabling SSR for wallet component
+const ConnectWallet = dynamic(() => import("@src/components/Wallet"), {
+  ssr: false,
+  loading: () => (
+    <Button type={"button"} variant={"solid"} size={"2"} radius={"full"}>
+      <Text weight="bold" wrap="nowrap">
+        Sign in
+      </Text>
+    </Button>
+  ),
+})
 
 export function Header({
   navbarSlot,

--- a/src/config/csp.ts
+++ b/src/config/csp.ts
@@ -95,6 +95,11 @@ const cspConfig = {
     "https://tc.architecton.su",
     "https://ton-connect.mytokenpocket.vip",
     "https://bridge.uxuy.me",
+    "https://tc.nicegram.app",
+    "https://connect.token.im",
+    "https://web3-bridge.kolo.in",
+    "https://ton-connect-bridge.echooo.link",
+    "https://blitzwallet.cfd",
 
     /** HOT */
     "http://*.herewallet.app",

--- a/src/providers/TonConnectUIProvider.tsx
+++ b/src/providers/TonConnectUIProvider.tsx
@@ -1,8 +1,16 @@
 "use client"
 
 import { APP_ENV } from "@src/utils/environment"
-import { TonConnectUIProvider } from "@tonconnect/ui-react"
+import dynamic from "next/dynamic"
 import type { ReactNode } from "react"
+
+// Disable SSR for TonConnectUIProvider to prevent hydration mismatch
+// The TON Connect library adds ontouchstart attribute to body during initialization,
+// which causes React hydration errors when server and client DOM don't match
+const TonConnectUIProvider = dynamic(
+  () => import("@tonconnect/ui-react").then((mod) => mod.TonConnectUIProvider),
+  { ssr: false }
+)
 
 function TonConnectUIProviderWrapper({ children }: { children: ReactNode }) {
   return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Wallet connect UI now loads client-side only to prevent hydration issues.
  - Displays a temporary “Sign in” button while the wallet UI initializes.
  - More reliable initialization of the TonConnect provider.

- Chores
  - Expanded Content Security Policy (connect-src) to allow additional wallet/bridge domains, ensuring successful connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->