### PR TITLE
fix: change ADA token name to Cardano

### DIFF
--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -1661,7 +1661,7 @@ export const PRODUCTION_TOKENS: (UnifiedTokenInfo_old | BaseTokenInfo_old)[] = [
     chainName: "cardano",
     bridge: "poa",
     symbol: "ADA",
-    name: "ADA",
+    name: "Cardano",
     tags: ["mc:10"],
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the displayed name of the native token from “ADA” to “Cardano” for clearer branding.
  - The new name appears across token lists, balances, portfolio views, send/receive flows, selectors, charts, and activity feeds.
  - Search, filters, and notifications now reference “Cardano.”
  - Visual labels only; no changes to functionality, balances, or transaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->