### PR TITLE
fix: correctly fetch balances for Stellar accounts with liquidity pool shares

### DIFF
--- a/src/components/DefuseSDK/services/blockchainBalanceService.ts
+++ b/src/components/DefuseSDK/services/blockchainBalanceService.ts
@@ -235,20 +235,23 @@ export const getStellarBalance = async ({
       v.object({
         balances: v.array(
           v.union([
+            // Native XLM asset
             v.object({
               asset_type: v.literal("native"),
               balance: v.string(),
             }),
-            // This schema describes *issued tokens* (non-native assets),
-            // which can be either credit_alphanum4 or credit_alphanum12.
-            // See: https://stellar.org/developers/guides/concepts/assets#asset-types
+            // Liquidity pool shares
+            v.object({
+              asset_type: v.literal("liquidity_pool_shares"),
+              balance: v.string(),
+            }),
+            // Credit alphanum4 and alphanum12 tokens
             v.object({
               asset_type: v.union([
                 v.literal("credit_alphanum4"),
                 v.literal("credit_alphanum12"),
               ]),
               asset_issuer: v.string(),
-              asset_code: v.string(),
               balance: v.string(),
             }),
           ])
@@ -280,7 +283,11 @@ function isStellarNativeToken(assetType: AssetType): boolean {
   return assetType === "native"
 }
 function isStellarTrustlineToken(assetType: AssetType): boolean {
-  return assetType === "credit_alphanum4" || assetType === "credit_alphanum12"
+  return (
+    assetType === "credit_alphanum4" ||
+    assetType === "credit_alphanum12" ||
+    assetType === "liquidity_pool_shares"
+  )
 }
 
 export const getTronNativeBalance = async ({

--- a/src/components/DefuseSDK/services/blockchainBalanceService.ts
+++ b/src/components/DefuseSDK/services/blockchainBalanceService.ts
@@ -260,14 +260,20 @@ export const getStellarBalance = async ({
       response
     )
 
-    const findTokenBalance = account.balances.find(
-      (balance) =>
-        (!tokenAddress && isStellarNativeToken(balance.asset_type)) ||
-        (tokenAddress &&
-          isStellarTrustlineToken(balance.asset_type) &&
-          "asset_issuer" in balance &&
-          balance.asset_issuer === tokenAddress)
-    )
+    const findTokenBalance = account.balances.find((balance) => {
+      if (!tokenAddress && isStellarNativeToken(balance.asset_type)) {
+        return true
+      }
+      if (
+        tokenAddress &&
+        isStellarTrustlineToken(balance.asset_type) &&
+        "asset_issuer" in balance &&
+        balance.asset_issuer === tokenAddress
+      ) {
+        return true
+      }
+      return false
+    })
     if (!findTokenBalance) {
       return 0n
     }
@@ -283,11 +289,7 @@ function isStellarNativeToken(assetType: AssetType): boolean {
   return assetType === "native"
 }
 function isStellarTrustlineToken(assetType: AssetType): boolean {
-  return (
-    assetType === "credit_alphanum4" ||
-    assetType === "credit_alphanum12" ||
-    assetType === "liquidity_pool_shares"
-  )
+  return assetType === "credit_alphanum4" || assetType === "credit_alphanum12"
 }
 
 export const getTronNativeBalance = async ({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Stellar liquidity pool share balances alongside native and trustline assets.

* **Bug Fixes**
  * More accurate selection and display of Stellar token balances, reducing missing or incorrect balances for liquidity pool shares and trustline tokens.

* **Chores**
  * Unified balance handling so liquidity pool shares are consistently recognized and processed across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->