### PR TITLE
feat(NearComPromo): deeplink to migration guide via Beacon

### DIFF
--- a/src/components/NearComPromo.tsx
+++ b/src/components/NearComPromo.tsx
@@ -20,11 +20,22 @@ const NearComPromo = () => {
   if (whitelabelTemplate !== "near-intents") return null
 
   const openMigrationGuide = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (typeof window !== "undefined" && typeof window.Beacon === "function") {
-      e.preventDefault()
-      window.Beacon("article", MIGRATION_ARTICLE_ID, { type: "sidebar" })
-    }
-    // else: let the browser follow the href (opens article in a new tab)
+    if (typeof window === "undefined") return
+    const beacon = window.Beacon
+    if (typeof beacon !== "function") return
+
+    // HelpScout installs a queueing stub (see Helpscout.tsx) before the
+    // real SDK finishes loading. The stub is a function with `readyQueue`
+    // as an array; the loaded SDK replaces the stub entirely and does not
+    // expose `readyQueue`. If we still see the stub here, the real SDK
+    // isn't ready (still loading, blocked by an extension, or failed),
+    // so skip preventDefault and let the <a href> navigate as a fallback.
+    const stubQueue = (beacon as unknown as { readyQueue?: unknown[] })
+      .readyQueue
+    if (Array.isArray(stubQueue)) return
+
+    e.preventDefault()
+    beacon("article", MIGRATION_ARTICLE_ID, { type: "sidebar" })
   }
 
   return (

--- a/src/components/NearComPromo.tsx
+++ b/src/components/NearComPromo.tsx
@@ -1,8 +1,12 @@
-import { useContext, useState } from "react"
+import { useContext } from "react"
 
 import { ChevronRightIcon } from "@radix-ui/react-icons"
 import { FeatureFlagsContext } from "@src/providers/FeatureFlagsProvider"
 import NearBadge from "../../public/static/icons/near-badge.svg"
+
+const MIGRATION_ARTICLE_ID = "69de575cfe9deda3e8da017c"
+const MIGRATION_ARTICLE_URL =
+  "https://near-intents-app.helpscoutdocs.com/article/257-migration-from-near-intents-to-nearcom"
 
 const NEAR_COM_LINK_PROPS = {
   href: "https://near.com/?utm_source=near-intents",
@@ -11,10 +15,17 @@ const NEAR_COM_LINK_PROPS = {
 }
 
 const NearComPromo = () => {
-  const [showReadMore, setShowReadMore] = useState(false)
   const { whitelabelTemplate } = useContext(FeatureFlagsContext)
 
   if (whitelabelTemplate !== "near-intents") return null
+
+  const openMigrationGuide = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (typeof window !== "undefined" && typeof window.Beacon === "function") {
+      e.preventDefault()
+      window.Beacon("article", MIGRATION_ARTICLE_ID, { type: "sidebar" })
+    }
+    // else: let the browser follow the href (opens article in a new tab)
+  }
 
   return (
     <div className="widget-container mx-auto mt-5 md:mt-8 px-3 sm:px-0 md:-mb-4">
@@ -30,33 +41,17 @@ const NearComPromo = () => {
           <a {...NEAR_COM_LINK_PROPS} className="text-white underline">
             near.com
           </a>{" "}
-          <br className="hidden sm:block" />— better app, same team. You can
-          continue here, but we encourage you to make the switch.{" "}
-          {!showReadMore && (
-            <button
-              type="button"
-              onClick={() => setShowReadMore(true)}
-              className="text-white underline text-left inline-block"
-            >
-              Read more
-            </button>
-          )}
+          — better app, same team. This site still works for now, but will be
+          phased out. We encourage you to migrate soon.
         </p>
-        {showReadMore && (
-          <p className="text-gray-400 text-sm font-medium mt-2">
-            Head over to{" "}
-            <a {...NEAR_COM_LINK_PROPS} className="text-white underline">
-              near.com
-            </a>{" "}
-            to get started. If you have funds here, you can transfer them to
-            your new account using NEAR Intents internal transfers.
-          </p>
-        )}
         <a
-          {...NEAR_COM_LINK_PROPS}
+          href={MIGRATION_ARTICLE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={openMigrationGuide}
           className="inline-flex items-center gap-1 mt-4 bg-white text-gray-900 px-4 rounded-xl py-3 -tracking-[0.01em]"
         >
-          <span className="text-sm/4 font-semibold">Go to near.com</span>
+          <span className="text-sm/4 font-semibold">Learn how to migrate</span>
           <ChevronRightIcon className="size-4 shrink-0" />
         </a>
       </div>

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -4,4 +4,5 @@ interface Window {
     eventName: string,
     additionalPayload?: T
   ) => void
+  Beacon?: (method: string, options?: unknown, data?: unknown) => void
 }


### PR DESCRIPTION
## Summary

- Simplifies the \"We've moved to near.com\" banner to a single call-to-action that opens the new migration help article directly in the HelpScout Beacon sidebar
- Strengthens the intro copy to acknowledge the site will be phased out (not just \"encourage you to switch\")
- Drops the \"Read more\" reveal + second paragraph in favor of the in-context help article
- Progressive enhancement: \`<a href>\` + onClick preventDefault when Beacon is loaded, falls back to opening the article in a new tab when it isn't (no-JS, ad blockers, lazy-load race, etc.)

## Motivation

The new migration help article (published today, article #257 on \`near-intents-app.helpscoutdocs.com\`) covers both the Web3-wallet path (nothing to do — the funds live on the protocol) and the passkey path (create new account + internal transfer). That's richer and clearer than duplicating a summary in the banner, so the banner should point users at the guide instead of trying to be the guide.

The guide's URL:
\`https://near-intents-app.helpscoutdocs.com/article/257-migration-from-near-intents-to-nearcom\`
Article ID: \`69de575cfe9deda3e8da017c\`

## Changes

- \`src/components/NearComPromo.tsx\` — copy update + CTA behavior
- \`src/types/env.d.ts\` — add \`Beacon\` to the existing Window interface augmentation (alongside \`gtag\`)

## Design decisions

1. **Progressive enhancement via \`<a href>\` + onClick**, not \`<button onClick>\`. Preserves right-click / new-tab affordance, works without JS, works when Beacon is blocked or still lazy-loading. See the handler in \`NearComPromo.tsx\`.
2. **Article ID hardcoded** as a file-level constant. HelpScout article IDs are stable; env-var-ifying would be overkill for a single migration-specific banner.
3. **Inline near.com link kept** in the intro text so users who want to click straight through still can. Single-action vs two-action is a style call — I kept both to avoid removing a working path.
4. **Removed \`useState\`** (no more \`showReadMore\`) and the second paragraph entirely. Simpler component, smaller footprint.

## Test plan

- [x] \`bun run typecheck\` — passes
- [x] \`bun run check\` (Biome) — passes
- [x] Dev server compiles cleanly on the branch
- [ ] **Production verification required after merge:** click \"Learn how to migrate\" in the deployed near-intents.org banner and confirm the HelpScout Beacon sidebar opens to article #257. Local verification is limited because \`NEXT_PUBLIC_HELPSCOUT_BEACON_ID\` isn't set in local env, so the Beacon path only runs in environments where it's configured.
- [ ] **Sanity check the Beacon ID association:** confirm the Beacon ID used on the production near-intents.org deploy is tied to the \`NEAR Intents Knowledge Base\` HelpScout docs site (id \`6985be2315239e64d5810791\`). If it's tied to a different site, the deep-link will silently fail and fall back to opening the article URL in a new tab — not broken, but not the intended UX.

## Risk

Low. Worst-case failure mode is the Beacon deep-link not finding the article → the \`<a href>\` fallback opens the article URL in a new tab. Banner remains visible and functional in all cases.

## Reviewers

Reviewers: Codex, Gemini

Created by Claude Opus 4.6.