### PR TITLE
refactor: read banned-accounts list from Edge Config

### DIFF
--- a/src/app/api/account/validate-banned/route.ts
+++ b/src/app/api/account/validate-banned/route.ts
@@ -1,13 +1,15 @@
 import { type AuthMethod, authIdentity } from "@defuse-protocol/internal-utils"
-import { BANNED_ACCOUNT_IDS } from "@src/utils/environment"
+import { isAccountBanned } from "@src/services/bannedAccounts"
 import { logger } from "@src/utils/logger"
 
 export const dynamic = "force-dynamic"
 
 /**
- * Validates if an account is banned based on address and chain type.
- * Currently uses environment variable (BANNED_ACCOUNT_IDS) from Vercel.
- * This can be later substituted with an external API call.
+ * Checks if an account (specified by address and chain type) is banned.
+ *
+ * Banned account intent IDs are stored as a JSON array under the Edge Config key
+ * `bannedAccountIds`, and managed via the Vercel Edge Config dashboard.
+ * Requires providing the `EDGE_CONFIG` environment variable (connection string).
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -22,8 +24,6 @@ export async function GET(request: Request) {
   }
 
   try {
-    // Map chainType string to AuthMethod enum
-    // ChainType enum values match AuthMethod values: "near", "evm", "solana", etc.
     const authMethod = chainType as AuthMethod
 
     const accountId = authIdentity.authHandleToIntentsUserId(
@@ -31,9 +31,7 @@ export async function GET(request: Request) {
       authMethod
     )
 
-    // Check against banned account IDs from environment variable
-    // TODO: Replace with external API call when available
-    const isBanned = accountId != null && BANNED_ACCOUNT_IDS.includes(accountId)
+    const isBanned = accountId != null && (await isAccountBanned(accountId))
 
     return Response.json({
       isBanned,

--- a/src/services/bannedAccounts.test.ts
+++ b/src/services/bannedAccounts.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { isAccountBanned } from "./bannedAccounts"
+
+const getMock = vi.fn()
+vi.mock("@vercel/edge-config", () => ({
+  get: (...args: unknown[]) => getMock(...args),
+}))
+
+describe("bannedAccounts", () => {
+  beforeEach(() => {
+    getMock.mockReset()
+  })
+
+  it("returns true for accounts in the Edge Config list", async () => {
+    getMock.mockResolvedValue(["banned.near", "0xabc"])
+
+    expect(await isAccountBanned("banned.near")).toBe(true)
+    expect(await isAccountBanned("clean.near")).toBe(false)
+    expect(getMock).toHaveBeenCalledWith("bannedAccountIds")
+  })
+
+  it("returns false when the Edge Config key is unset", async () => {
+    getMock.mockResolvedValue(undefined)
+
+    expect(await isAccountBanned("anyone.near")).toBe(false)
+  })
+
+  it("fails closed when get throws", async () => {
+    getMock.mockRejectedValue(new Error("edge config outage"))
+
+    expect(await isAccountBanned("anyone.near")).toBe(true)
+  })
+
+  it("fails closed when the stored value is not a string array", async () => {
+    getMock.mockResolvedValue({ not: "an array" })
+
+    expect(await isAccountBanned("anyone.near")).toBe(true)
+  })
+
+  it("fails closed when the array contains non-string entries", async () => {
+    getMock.mockResolvedValue(["ok.near", 42])
+
+    expect(await isAccountBanned("ok.near")).toBe(true)
+  })
+})

--- a/src/services/bannedAccounts.ts
+++ b/src/services/bannedAccounts.ts
@@ -1,0 +1,27 @@
+import { logger } from "@src/utils/logger"
+import { get } from "@vercel/edge-config"
+import * as v from "valibot"
+
+const EDGE_CONFIG_KEY = "bannedAccountIds"
+const BannedListSchema = v.array(v.string())
+
+async function getBannedAccountIds(): Promise<string[]> {
+  const raw = await get(EDGE_CONFIG_KEY)
+  if (raw === undefined) {
+    logger.warn(
+      `Edge Config key "${EDGE_CONFIG_KEY}" is not set; treating list as empty`
+    )
+    return []
+  }
+  return v.parse(BannedListSchema, raw)
+}
+
+export async function isAccountBanned(accountId: string): Promise<boolean> {
+  try {
+    const ids = await getBannedAccountIds()
+    return ids.includes(accountId)
+  } catch (err) {
+    logger.error("Failed to load banned account list; failing closed", { err })
+    return true
+  }
+}

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -78,8 +78,3 @@ export const APP_NETWORK_OUTAGE_NOTIFICATION = v.parse(
   v.optional(v.string(), ""),
   process.env.NEXT_PUBLIC_APP_NETWORK_OUTAGE_NOTIFICATION
 )
-
-export const BANNED_ACCOUNT_IDS = v.parse(
-  v.optional(v.array(v.string()), []),
-  process.env.NEXT_PUBLIC_BANNED_ACCOUNT_IDS?.split(",").filter(Boolean)
-)


### PR DESCRIPTION
## Summary

- Move the banned-accounts list out of the build-time `NEXT_PUBLIC_BANNED_ACCOUNT_IDS` env var and into Vercel Edge Config (key: `bannedAccountIds`), so it can be updated from the dashboard without a redeploy.
- New `isAccountBanned()` service **fails closed** — any read or schema-parse failure returns `true`, so an Edge Config outage cannot silently let banned accounts through.
- Ports defuse-protocol/defuse-near#464.

## Deploy notes

- Set the `EDGE_CONFIG` connection string in each deployment environment.
- Seed the `bannedAccountIds` key in the Vercel Edge Config dashboard as a JSON array of strings (intent user IDs), e.g. `["banned.near", "0xabc"]`. If unset, the service logs a warn and treats the list as empty.
- `NEXT_PUBLIC_BANNED_ACCOUNT_IDS` is no longer read and can be removed from every environment.

## Follow-up (not in this PR)

`.env.local.example` still contains the now-unused `NEXT_PUBLIC_BANNED_ACCOUNT_IDS=` line (lines 29-30). My local tooling blocks edits under that path, so it needs a manual one-line removal before merge — happy to do it in a follow-up commit if preferred.

## Test plan

- [x] `pnpm vitest run src/services/bannedAccounts.test.ts` — 5/5 pass (includes fail-closed cases for thrown errors, wrong shape, and non-string entries).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm check` (biome) on touched files — clean.
- [x] `rg BANNED_ACCOUNT_IDS` — no remaining references in source (only the `.env.local.example` line called out above).
- [ ] Manual: with `EDGE_CONFIG` unset, `GET /api/account/validate-banned?address=…&chainType=near` returns `isBanned: false` and emits a warn log.
- [ ] Manual: with a bogus `EDGE_CONFIG` value, the same request returns `isBanned: true` (fail-closed) and emits an error log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)